### PR TITLE
Set default CSV options to 'CSV'

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ $ timescaledb-parallel-copy --db-name test --table sample --file foo.csv \
 # 2 workers, report progress every 30s
 $ timescaledb-parallel-copy --db-name test --table sample --file foo.csv \
     --workers 2 --reporting-period 30s
+
+# Treat literal string 'NULL' as NULLs:
+$ timescaledb-parallel-copy --db-name test --table sample --file foo.csv \
+    --copy-options "NULL 'NULL' CSV"
 ```
 
 Other options and flags are also available, use

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func init() {
 	flag.StringVar(&schemaName, "schema", "public", "Desination table's schema")
 	flag.BoolVar(&truncate, "truncate", false, "Truncate the destination table before insert")
 
-	flag.StringVar(&copyOptions, "copy-options", "", "Additional options to pass to COPY (ex. NULL 'NULL')")
+	flag.StringVar(&copyOptions, "copy-options", "CSV", "Additional options to pass to COPY (e.g., NULL 'NULL')")
 	flag.StringVar(&splitCharacter, "split", ",", "Character to split by")
 	flag.StringVar(&fromFile, "file", "", "File to read from rather than stdin")
 	flag.StringVar(&columns, "columns", "", "Comma-separated columns present in CSV")


### PR DESCRIPTION
This will handle files in correct CSV format by default, rather
than have the users discover this option themselves. Also update
README to include a `--copy-options` example.

Fixes #10 