### PR TITLE
Add --skip-header flag.

### DIFF
--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -34,6 +34,7 @@ var (
 	splitCharacter string
 	fromFile       string
 	columns        string
+	skipHeader     bool
 
 	workers         int
 	batchSize       int
@@ -62,6 +63,7 @@ func init() {
 	flag.StringVar(&splitCharacter, "split", ",", "Character to split by")
 	flag.StringVar(&fromFile, "file", "", "File to read from rather than stdin")
 	flag.StringVar(&columns, "columns", "", "Comma-separated columns present in CSV")
+	flag.BoolVar(&skipHeader, "skip-header", false, "Skip the first line of the input")
 
 	flag.IntVar(&batchSize, "batch-size", 5000, "Number of rows per insert")
 	flag.IntVar(&workers, "workers", 1, "Number of parallel requests to make")
@@ -170,6 +172,13 @@ func report() {
 func scan(itemsPerBatch int, scanner *bufio.Scanner, batchChan chan *batch) int64 {
 	rows := make([]string, 0, itemsPerBatch)
 	var linesRead int64
+
+	if skipHeader {
+		if verbose {
+			fmt.Println("Skipping the first line of the input.")
+		}
+		scanner.Scan()
+	}
 
 	for scanner.Scan() {
 		linesRead++


### PR DESCRIPTION
Add the option to skip the header line, which is quite common in csv files. This cannot be done via `--copy-options`, because these will be applied every time the prepared statement is run.

To test, add a header line to the [csv file](https://timescaledata.blob.core.windows.net/datasets/nyc_data.tar.gz) from the [getting started tutorial](https://docs.timescale.com/v1.2/tutorials/tutorial-hello-nyc).
`vendor_id,pickup_datetime,dropoff_datetime,passenger_count,trip_distance,pickup_longitude,pickup_latitude,rate_code,dropoff_longitude,dropoff_latitude,payment_type,fare_amount,extra,mta_tax,tip_amount,tolls_amount,improvement_surcharge,total_amount`

Observe that importing it without the `--skip-header`, this fails:
`panic: pq: invalid input syntax for type timestamp: "pickup_datetime"`

The import will work when using `--skip-header`.

CLA signed.