### PR TITLE
Remove the columnCount variable and only split line if necessary.

### DIFF
--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -42,8 +42,7 @@ var (
 	verbose         bool
 	showVersion     bool
 
-	columnCount int64
-	rowCount    int64
+	rowCount int64
 )
 
 type batch struct {
@@ -198,7 +197,6 @@ func processBatches(wg *sync.WaitGroup, C chan *batch) {
 	dbBench := sqlx.MustConnect("postgres", getConnectString())
 	defer dbBench.Close()
 
-	columnCountWorker := int64(0)
 	for batch := range C {
 		start := time.Now()
 
@@ -225,17 +223,15 @@ func processBatches(wg *sync.WaitGroup, C chan *batch) {
 			sChar = "\t"
 		}
 		for _, line := range batch.rows {
-			sp := strings.Split(line, sChar)
-			columnCountWorker += int64(len(sp))
 			// For some reason this is only needed for tab splitting
 			if sChar == "\t" {
+				sp := strings.Split(line, sChar)
 				args := make([]interface{}, len(sp))
 				for i, v := range sp {
 					args[i] = v
 				}
 				_, err = stmt.Exec(args...)
 			} else {
-
 				_, err = stmt.Exec(line)
 			}
 
@@ -243,9 +239,8 @@ func processBatches(wg *sync.WaitGroup, C chan *batch) {
 				panic(err)
 			}
 		}
-		atomic.AddInt64(&columnCount, columnCountWorker)
+
 		atomic.AddInt64(&rowCount, int64(len(batch.rows)))
-		columnCountWorker = 0
 
 		err = stmt.Close()
 		if err != nil {


### PR DESCRIPTION
There's a variable called `columnCount` in the code that is only written to, but never read. If there was any use for it at some point, the corresponding code must have been removed.

Removing this variable allows us to only split the line only when required by the workaround.

CLA signed.