### PR TITLE
Added command line option to allow several header lines

### DIFF
--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -198,7 +198,7 @@ func scan(itemsPerBatch int, scanner *bufio.Scanner, batchChan chan *batch) int6
 
 	if skipHeader {
 		if verbose {
-			fmt.Printf("Skipping the first %i lines of the input.\n", headerLinesCnt)
+			fmt.Printf("Skipping the first %d lines of the input.\n", headerLinesCnt)
 		}
 		for i := 0; i < headerLinesCnt; i++ {
 			scanner.Scan()

--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -127,8 +127,8 @@ func main() {
 		scanner = bufio.NewScanner(os.Stdin)
 	}
 
-	if headerLinesCnt < 0 {
-		fmt.Printf("WARNING: provided --header-line-count (%d) is negative, only positive allowed\n", headerLinesCnt)
+	if headerLinesCnt <= 0 {
+		fmt.Printf("WARNING: provided --header-line-count (%d) must be greater than 0\n", headerLinesCnt)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
When i was working on some csv file i came across file which had 2 header lines, with this pull request i added an option where you can specify the number of header lines you want to skip.