### PR TITLE
Add additional details to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,16 @@ Usage of timescaledb-parallel-copy:
         Number of parallel requests to make (default 1)
 ```
 
+### Purpose
+
+PostgreSQL native `COPY` function is transactional and single-threaded, and may not be suitable for ingesting large
+amounts of data. Assuming the file is at least loosely chronologically ordered with respect to the hypertable's time
+dimension, this tool should give you great performance gains by parallelizing this operation, allowing users to take
+full advantage of their hardware.
+
+This tool also takes care to ingest data in a more efficient manner by roughly preserving the order of the rows. By
+taking a "round-robin" approach to sharing inserts between parallel workers, the database has to switch between chunks
+less often. This improves memory management and keeps operations on the disk as sequential as possible.
+
 ### Contributing
 We welcome contributions to this utility, which like TimescaleDB is released under the Apache2 Open Source License.  The same [Contributors Agreement](//github.com/timescale/timescaledb/blob/master/CONTRIBUTING.md) applies; please sign the [Contributor License Agreement](https://cla-assistant.io/timescale/timescaledb-parallel-copy) (CLA) if you're a new contributor.


### PR DESCRIPTION
An outsider may not be aware that PostgreSQL `COPY` is limited by
its single-threaded nature. In addition, it is useful for users and
developers looking at the codebase to immediately grasp the key
functions of this tool (parallization & doing it in an efficient
manner with round robin).

The explanation for this comes from @mfreed, I've only edited it to make it fit better with the README.md. See his original comment [here](https://github.com/timescale/timescaledb-parallel-copy/issues/42#issuecomment-736927094).