### PR TITLE
go get no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ into [TimescaleDB.](//github.com/timescale/timescaledb/)
 ### Getting started
 You need the Go runtime (1.6+) installed, then simply `go get` this repo:
 ```bash
-$ go get github.com/timescale/timescaledb-parallel-copy/cmd/timescaledb-parallel-copy
+$ go install github.com/timescale/timescaledb-parallel-copy/cmd/timescaledb-parallel-copy@latest
 ```
 
 Before using this program to bulk insert data, your database should


### PR DESCRIPTION
Go get is no longer supported

```
go get github.com/timescale/timescaledb-parallel-copy/cmd/timescaledb-parallel-copy
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

To install the package outside the module:
```
go install github.com/timescale/timescaledb-parallel-copy/cmd/timescaledb-parallel-copy@latest
```