### PR TITLE
Add workflow to move issue to triage

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,17 @@
+name: Add bugs to bugs project
+
+on:
+  issues:
+    types: [ opened, labeled ]
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.1.0
+        with:
+          project-url: https://github.com/orgs/timescale/projects/55
+          # Token will expire Oct 2, 2022
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: bug


### PR DESCRIPTION
Add workflow to automatically add all issues opened or labeled to the
bug board for triage.