### PR TITLE
Don't split multi-line rows across batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Usage of timescaledb-parallel-copy:
         Additional options to pass to COPY (e.g., NULL 'NULL') (default "CSV")
   -db-name string
         Database where the destination table exists
+  -escape character
+        The ESCAPE character to use during COPY (default '"')
   -file string
         File to read from rather than stdin
   -header-line-count int
@@ -59,6 +61,8 @@ Usage of timescaledb-parallel-copy:
         Number of rows to insert overall; 0 means to insert all
   -log-batches
         Whether to time individual batches.
+  -quote character
+        The QUOTE character to use during COPY (default '"')
   -reporting-period duration
         Period to report insert stats; if 0s, intermediate results will not be reported
   -schema string

--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -150,8 +150,14 @@ func main() {
 		go report()
 	}
 
+	opts := batch.Options{
+		Size:  batchSize,
+		Skip:  skip,
+		Limit: limit,
+	}
+
 	start := time.Now()
-	if err := batch.Scan(batchSize, skip, limit, reader, batchChan); err != nil {
+	if err := batch.Scan(reader, batchChan, opts); err != nil {
 		log.Fatalf("Error reading input: %s", err.Error())
 	}
 

--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -21,7 +22,7 @@ import (
 
 const (
 	binName    = "timescaledb-parallel-copy"
-	version    = "0.4.0"
+	version    = "0.4.1-dev"
 	tabCharStr = "\\t"
 )
 
@@ -33,8 +34,11 @@ var (
 	tableName       string
 	truncate        bool
 
-	copyOptions    string
-	splitCharacter string
+	copyOptions     string
+	splitCharacter  string
+	quoteCharacter  string
+	escapeCharacter string
+
 	fromFile       string
 	columns        string
 	skipHeader     bool
@@ -62,6 +66,8 @@ func init() {
 
 	flag.StringVar(&copyOptions, "copy-options", "CSV", "Additional options to pass to COPY (e.g., NULL 'NULL')")
 	flag.StringVar(&splitCharacter, "split", ",", "Character to split by")
+	flag.StringVar(&quoteCharacter, "quote", "", "The QUOTE `character` to use during COPY (default '\"')")
+	flag.StringVar(&escapeCharacter, "escape", "", "The ESCAPE `character` to use during COPY (default '\"')")
 	flag.StringVar(&fromFile, "file", "", "File to read from rather than stdin")
 	flag.StringVar(&columns, "columns", "", "Comma-separated columns present in CSV")
 	flag.BoolVar(&skipHeader, "skip-header", false, "Skip the first line of the input")
@@ -91,6 +97,16 @@ func main() {
 	if showVersion {
 		fmt.Printf("%s %s (%s %s)\n", binName, version, runtime.GOOS, runtime.GOARCH)
 		os.Exit(0)
+	}
+
+	if len(quoteCharacter) > 1 {
+		fmt.Println("ERROR: provided --quote must be a single-byte character")
+		os.Exit(1)
+	}
+
+	if len(escapeCharacter) > 1 {
+		fmt.Println("ERROR: provided --escape must be a single-byte character")
+		os.Exit(1)
 	}
 
 	if truncate { // Remove existing data from the table
@@ -156,6 +172,15 @@ func main() {
 		Limit: limit,
 	}
 
+	if quoteCharacter != "" {
+		// we already verified the length above
+		opts.Quote = quoteCharacter[0]
+	}
+	if escapeCharacter != "" {
+		// we already verified the length above
+		opts.Escape = escapeCharacter[0]
+	}
+
 	start := time.Now()
 	if err := batch.Scan(reader, batchChan, opts); err != nil {
 		log.Fatalf("Error reading input: %s", err.Error())
@@ -212,11 +237,21 @@ func processBatches(wg *sync.WaitGroup, c chan net.Buffers) {
 		delimStr = "E" + delimStr
 	}
 
+	var quotes string
+	if quoteCharacter != "" {
+		quotes = fmt.Sprintf("QUOTE '%s'",
+			strings.ReplaceAll(quoteCharacter, "'", "''"))
+	}
+	if escapeCharacter != "" {
+		quotes = fmt.Sprintf("%s ESCAPE '%s'",
+			quotes, strings.ReplaceAll(escapeCharacter, "'", "''"))
+	}
+
 	var copyCmd string
 	if columns != "" {
-		copyCmd = fmt.Sprintf("COPY %s(%s) FROM STDIN WITH DELIMITER %s %s", getFullTableName(), columns, delimStr, copyOptions)
+		copyCmd = fmt.Sprintf("COPY %s(%s) FROM STDIN WITH DELIMITER %s %s %s", getFullTableName(), columns, delimStr, quotes, copyOptions)
 	} else {
-		copyCmd = fmt.Sprintf("COPY %s FROM STDIN WITH DELIMITER %s %s", getFullTableName(), delimStr, copyOptions)
+		copyCmd = fmt.Sprintf("COPY %s FROM STDIN WITH DELIMITER %s %s %s", getFullTableName(), delimStr, quotes, copyOptions)
 	}
 
 	for batch := range c {

--- a/internal/batch/scan.go
+++ b/internal/batch/scan.go
@@ -12,16 +12,23 @@ type Options struct {
 	Size  int   // maximum number of rows per batch
 	Skip  int   // how many header lines to skip at the beginning
 	Limit int64 // total number of rows to scan after the header
+
+	Quote  byte // the QUOTE character; defaults to '"'
+	Escape byte // the ESCAPE character; defaults to QUOTE
 }
 
 // Scan reads all lines from an io.Reader, partitions them into net.Buffers with
-// opts.Size lines each, and writes each batch to the out channel. If opts.Skip
+// opts.Size rows each, and writes each batch to the out channel. If opts.Skip
 // is greater than zero, that number of lines will be discarded from the
 // beginning of the data. If opts.Limit is greater than zero, then Scan will
-// stop once it has written that number of lines, across all batches, to the
+// stop once it has written that number of rows, across all batches, to the
 // channel.
+//
+// Scan expects the input to be in Postgres CSV format. Since this format allows
+// rows to be split over multiple lines, the caller may provide opts.Quote and
+// opts.Escape as the QUOTE and ESCAPE characters used for the CSV input.
 func Scan(r io.Reader, out chan<- net.Buffers, opts Options) error {
-	var linesRead int64
+	var rowsRead int64
 	reader := bufio.NewReader(r)
 
 	for skip := opts.Skip; skip > 0; {
@@ -37,10 +44,22 @@ func Scan(r io.Reader, out chan<- net.Buffers, opts Options) error {
 		}
 
 		if !isPrefix {
-			// We pulled a full line from the buffer.
+			// We pulled a full row from the buffer.
 			skip--
 		}
 	}
+
+	quote := byte('"')
+	if opts.Quote != 0 {
+		quote = opts.Quote
+	}
+
+	escape := quote
+	if opts.Escape != 0 {
+		escape = opts.Escape
+	}
+
+	scanner := makeCSVRowState(quote, escape)
 
 	// We read a continuous stream of []byte from our buffered reader. Rather
 	// than coalesce all of the incoming slices into a single contiguous buffer
@@ -50,9 +69,11 @@ func Scan(r io.Reader, out chan<- net.Buffers, opts Options) error {
 	// the slices as-is and store them in net.Buffers, which is a convenient
 	// io.Reader abstraction wrapped over a [][]byte.
 	bufs := make(net.Buffers, 0, opts.Size)
-	var bufferedLines int
+	var bufferedRows int
 
 	for {
+		eol := false
+
 		data, err := reader.ReadSlice('\n')
 
 		switch err {
@@ -67,8 +88,7 @@ func Scan(r io.Reader, out chan<- net.Buffers, opts Options) error {
 
 		case nil:
 			// We read a full line from the input.
-			bufferedLines++
-			linesRead++
+			eol = true
 
 		default:
 			return err
@@ -81,17 +101,25 @@ func Scan(r io.Reader, out chan<- net.Buffers, opts Options) error {
 			copy(buf, data)
 			bufs = append(bufs, buf)
 
-			if bufferedLines >= opts.Size { // dispatch to COPY worker & reset
+			// Figure out whether we're still inside a quoted value, in which
+			// case the row hasn't ended yet even if we're at the end of a line.
+			scanner.Scan(buf)
+			if eol && !scanner.NeedsMore() {
+				bufferedRows++
+				rowsRead++
+			}
+
+			if bufferedRows >= opts.Size { // dispatch to COPY worker & reset
 				out <- bufs
 				bufs = make(net.Buffers, 0, opts.Size)
-				bufferedLines = 0
+				bufferedRows = 0
 			}
 		}
 
 		// Check termination conditions.
 		if err == io.EOF {
 			break
-		} else if opts.Limit != 0 && linesRead >= opts.Limit {
+		} else if opts.Limit != 0 && rowsRead >= opts.Limit {
 			break
 		}
 	}
@@ -102,4 +130,96 @@ func Scan(r io.Reader, out chan<- net.Buffers, opts Options) error {
 	}
 
 	return nil
+}
+
+// csvRowState maintains a basic parse state for the Postgres CSV format. It's
+// designed to help clients maintain an accurate row count even when quoted rows
+// are split over multiple lines.
+type csvRowState struct {
+	quote, escape byte // delimiters
+
+	// scan state
+	inQuote  bool // are we in an open quoted value?
+	inEscape bool // are we (potentially) in an open escape sequence?
+}
+
+// makeCSVRowState initializes a new csvRowState with the given delimiters.
+func makeCSVRowState(quote, escape byte) *csvRowState {
+	return &csvRowState{
+		quote:  quote,
+		escape: escape,
+	}
+}
+
+// Scan reads raw line data from a CSV stream. After feeding data to Scan, the
+// parse state may be checked by calling NeedsMore.
+//
+// Note that newline characters (and whitespace characters in general) are
+// significant in Postgres CSV format and MUST NOT be stripped from the stream
+// that is given to Scan. (This property is met by bufio.Reader's ReadSlice
+// method.)
+func (c *csvRowState) Scan(buf []byte) {
+	for _, b := range buf {
+		// If we think the previous character might have been an escape, the
+		// current character might need to be ignored.
+		if c.inEscape {
+			c.inEscape = false
+
+			// Only the quote and escape delimiters can themselves be escaped.
+			switch b {
+			case c.quote, c.escape:
+				// Okay, it was really an escape and we should ignore this.
+				continue
+			}
+
+			// NB: this is the strangest corner case of the Postgres CSV
+			// format. If the quote and escape delimiters are the same character
+			// -- e.g. in the default case, where both are a double-quote (") --
+			// and we're to this point in the code, then the last escape
+			// character we saw was actually an ending quote, and we need to
+			// make sure the state reflects that before continuing.
+			//
+			// (As a concrete example, consider a buffer with the following
+			// data at the start:
+			//
+			//     "hello world"
+			//
+			// If the next character in the buffer is a double-quote, then we're
+			// still inside an open quoted value, since the "" sequence is
+			// replaced with a literal double-quote. But if the next character
+			// is a comma, then this is a complete quoted value.)
+			//
+			// The Postgres code handles this case with a lookahead, but we
+			// don't always have the ability to do that here, since we're
+			// operating on a buffer stream.
+			if c.quote == c.escape {
+				c.inQuote = false
+			}
+		}
+
+		// Escape sequences are only recognized inside of a quoted value;
+		// otherwise the escape character has no special meaning.
+		if c.inQuote && (b == c.escape) {
+			c.inEscape = true
+			continue
+		}
+
+		if b == c.quote {
+			// We know this is an unescaped quote delimiter, so we're either
+			// beginning or ending a quoted string.
+			c.inQuote = !c.inQuote
+		}
+	}
+}
+
+// NeedsMore returns true if the current row is incomplete: the previous buffers
+// given to Scan opened a quoted value that has not yet been closed.
+//
+// Note that even if NeedsMore returns false, that does NOT imply that the
+// current position is at the end of a row. (To decide that, the caller needs to
+// track whether the stream is also at the end of a line.)
+func (c *csvRowState) NeedsMore() bool {
+	// We don't need to check c.inEscape, because that can only be true if
+	// c.inQuote is also true.
+	return c.inQuote
 }

--- a/internal/batch/scan_internal_test.go
+++ b/internal/batch/scan_internal_test.go
@@ -1,0 +1,275 @@
+package batch
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgconn"
+	"github.com/jmoiron/sqlx"
+	"github.com/timescale/timescaledb-parallel-copy/internal/db"
+)
+
+func TestCSVRowState(t *testing.T) {
+	cases := []struct {
+		name          string
+		input         []string
+		quote, escape rune // default '"'
+		expectMore    bool
+	}{
+		{
+			name: "quoted value",
+			input: []string{
+				`"hello there"` + "\n",
+			},
+			expectMore: false,
+		},
+		{
+			name: "empty value",
+			input: []string{
+				`""` + "\n",
+			},
+			expectMore: false,
+		},
+		{
+			name: "quoted value with escaped quote",
+			input: []string{
+				`"hello""there"` + "\n",
+			},
+			expectMore: false,
+		},
+		{
+			name:   "quoted value with custom-escaped quote",
+			escape: '\\',
+			input: []string{
+				`"hello\"there"` + "\n",
+			},
+			expectMore: false,
+		},
+		{
+			name:   "quoted value with escaped escape",
+			escape: '\\',
+			input: []string{
+				`"hello\\"` + "\n",
+			},
+			expectMore: false,
+		},
+		{
+			name:   "quoted value with invalid escape",
+			escape: '\\',
+			input: []string{
+				`"hello\,"` + "\n",
+			},
+			expectMore: false,
+		},
+		{
+			name: "leaving a quote open",
+			input: []string{
+				`"hello there`,
+			},
+			expectMore: true,
+		},
+		{
+			name:  "leaving a custom quote open",
+			quote: '\'',
+			input: []string{
+				`'hello there`,
+			},
+			expectMore: true,
+		},
+		{
+			name: "leaving a quote open with standard escapes",
+			input: []string{
+				`"hello""there`,
+			},
+			expectMore: true,
+		},
+		{
+			name:   "leaving a quote open with custom quotes and escapes",
+			quote:  '\'',
+			escape: '\\',
+			input: []string{
+				`'hello\'there`,
+			},
+			expectMore: true,
+		},
+		{
+			name: "splitting a quoted value across chunks",
+			input: []string{
+				`"hello `,
+				`there"` + "\n",
+			},
+			expectMore: false,
+		},
+		{
+			name: "splitting a quoted value with standard escapes",
+			input: []string{
+				`"foo `,
+				`bar""baz"` + "\n",
+			},
+			expectMore: false,
+		},
+		{
+			name:   "splitting a quoted value with custom escapes",
+			escape: '\\',
+			input: []string{
+				`"foo `,
+				`bar\"baz"` + "\n",
+			},
+			expectMore: false,
+		},
+		{
+			name: "closing and reopening a quote across chunks",
+			input: []string{
+				`"foo `,
+				`b"ar ba"z`,
+			},
+			expectMore: true,
+		},
+		{
+			// This case and the next are subtly different. Escapes aren't
+			// recognized until you're in a quoted value, but escapes and quotes
+			// can be the same character.
+			name: "closing and reopening a quote with doubled quotes",
+			input: []string{
+				`"foo `,
+				`b"ar""ba"z`,
+			},
+			expectMore: true,
+		},
+		{
+			// Unlike the last case, the backslash here receives no special
+			// treatment, because it's not inside a quoted value.
+			name:   "closing and reopening a quote with unquoted escape",
+			escape: '\\',
+			input: []string{
+				`"foo `,
+				`b"ar\"ba"z`,
+			},
+			expectMore: false,
+		},
+		{
+			name: "splitting a standard escape sequence across chunks",
+			input: []string{
+				`"hello "`,
+				`"there"` + "\n",
+			},
+			expectMore: false,
+		},
+		{
+			name:   "splitting a custom escape sequence across chunks",
+			escape: '\\',
+			input: []string{
+				`"hello \`,
+				`"there"` + "\n",
+			},
+			expectMore: false,
+		},
+		{
+			name:   "splitting a misleading escape sequence across chunks",
+			escape: '\\',
+			input: []string{
+				// The first backslash escapes the next, causing the second
+				// double-quote to close the quote, then the third double-quote
+				// reopens it.
+				`"hello \`,
+				`\"there"` + "\n",
+			},
+			expectMore: true,
+		},
+	}
+
+	for _, c := range cases {
+		copyOpts := "CSV"
+
+		quote := byte('"')
+		if c.quote != 0 {
+			quote = byte(c.quote)
+			copyOpts = fmt.Sprintf("%s QUOTE '%s'",
+				copyOpts, strings.ReplaceAll(string(c.quote), "'", "''"))
+		}
+
+		escape := byte('"')
+		if c.escape != 0 {
+			escape = byte(c.escape)
+			copyOpts = fmt.Sprintf("%s ESCAPE '%s'",
+				copyOpts, strings.ReplaceAll(string(c.escape), "'", "''"))
+		}
+
+		t.Run(c.name, func(t *testing.T) {
+			scanner := makeCSVRowState(quote, escape)
+
+			for _, chunk := range c.input {
+				scanner.Scan([]byte(chunk))
+			}
+
+			if scanner.NeedsMore() != c.expectMore {
+				t.Errorf("NeedsMore() = %v, want %v", scanner.NeedsMore(), c.expectMore)
+				t.Logf("escape = %q, quote = %q", escape, quote)
+				t.Logf("input data was %q", c.input)
+			}
+		})
+
+		// Constructing test cases for CSV quote parsing can be tricky, since
+		// the corner cases are underdocumented. If the developer provides a
+		// TEST_CONNINFO, we can sanity-check by making sure a real database
+		// actually rejects the unterminated test cases and accepts all the
+		// others.
+		t.Run(fmt.Sprintf("live DB check: %s", c.name), func(t *testing.T) {
+			d := mustConnect(t)
+			defer d.Close()
+
+			d.MustExec(`CREATE TABLE csv(t text)`)
+			defer d.MustExec(`DROP TABLE csv`)
+
+			allLines := strings.Join(c.input, "")
+			copyCmd := fmt.Sprintf(`COPY csv FROM STDIN WITH %s`, copyOpts)
+
+			num, err := db.CopyFromLines(d, strings.NewReader(allLines), copyCmd)
+
+			if c.expectMore {
+				// If our test case claimed to be unterminated, then the DB
+				// should have also complained about an unterminated row.
+				expected := "22P04" // bad COPY format
+
+				var pgerr *pgconn.PgError
+				if !errors.As(err, &pgerr) {
+					t.Fatalf("CopyFromLines() returned error %#v, want type %T", err, pgerr)
+				}
+				if pgerr.Code != expected {
+					t.Errorf("database reported error code %q, want %q", pgerr.Code, expected)
+				}
+
+				return
+			}
+
+			// Otherwise, exactly one row should have been correctly inserted.
+			if err != nil {
+				t.Errorf("CopyFromLines() returned unexpected error: %v", err)
+			}
+			if num != 1 {
+				t.Errorf("CopyFromLines() inserted %d rows, want %d", num, 1)
+			}
+		})
+	}
+}
+
+// mustConnect reads the TEST_CONNINFO environment variable and attempts to
+// connect to the database it points to. If the variable doesn't exist (or is
+// empty), the test is skipped. If it exists but can't be used to connect, the
+// test fails. The new database connection is returned.
+func mustConnect(t *testing.T) *sqlx.DB {
+	conninfo := os.Getenv("TEST_CONNINFO")
+	if len(conninfo) == 0 {
+		t.Skip("the TEST_CONNINFO environment variable must point to a running database")
+	}
+
+	d, err := db.Connect(conninfo)
+	if err != nil {
+		t.Fatalf("failed to connect using TEST_CONNINFO: %v", err)
+	}
+
+	return d
+}

--- a/internal/batch/scan_test.go
+++ b/internal/batch/scan_test.go
@@ -156,8 +156,13 @@ func TestScan(t *testing.T) {
 
 			all := strings.Join(c.input, "\n")
 			reader := strings.NewReader(all)
+			opts := batch.Options{
+				Size:  c.size,
+				Skip:  c.skip,
+				Limit: c.limit,
+			}
 
-			err := batch.Scan(c.size, c.skip, c.limit, reader, rowChan)
+			err := batch.Scan(reader, rowChan, opts)
 			if err != nil {
 				t.Fatalf("Scan() returned error: %v", err)
 			}
@@ -197,8 +202,12 @@ func TestScan(t *testing.T) {
 			`), expected)
 
 			rowChan := make(chan net.Buffers, 1)
+			opts := batch.Options{
+				Size: 50,
+				Skip: c.skip,
+			}
 
-			err := batch.Scan(50, c.skip, 0, reader, rowChan)
+			err := batch.Scan(reader, rowChan, opts)
 			if !errors.Is(err, expected) {
 				t.Errorf("Scan() returned unexpected error: %v", err)
 				t.Logf("want: %v", expected)


### PR DESCRIPTION
As mentioned in https://github.com/timescale/timescaledb-parallel-copy/commit/8da678ea9800d89e5fa9539819fff92ec0630a99, https://github.com/timescale/timescaledb-parallel-copy/issues/19, and https://github.com/timescale/timescaledb-parallel-copy/issues/50, the batching algorithm assumes that one row consists of exactly one line. If a row contains multi-line quoted column values, and we happen to split that row across multiple batches, we'll fail the `COPY`.

Add a naive CSV parser to Scan() which prevents this accidental splitting. This parser searches the incoming CSV for the `QUOTE` and `ESCAPE` characters (which can be customized by the new `-quote` and `-escape` flags to the tool), and prevents Scan() from sending out a new batch if it detects that we're still inside a quoted value.

Because it's imperative that our parser matches the Postgres CSV parser exactly (and the rules for parsing are not as intuitive as the rules for production), a wide variety of test cases have been added. Running the suite with `TEST_CONNINFO` will additionally run these test cases against a live Postgres server, as a sanity check to ensure that each case was coded correctly.

This implementation adds a significant CPU hit, in the form of naive iteration over every byte in the input. I duplicated each benchmark, to measure the case where `QUOTE` and `ESCAPE` are the same and the case where they are different. (The code paths diverge enough that it may be useful to optimize them separately.)

For the following machine (with CPU scaling disabled to the best of my knowledge):

    goos: linux
    goarch: amd64
    pkg: github.com/timescale/timescaledb-parallel-copy/internal/batch
    cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz

benchstat reports the following changes as of this commit, when compared to the previous one:

    $ benchstat original.txt multiline.txt
    name                                                    old time/op  new time/op  delta
    Scan/warmup_(disregard)_(standard_escapes)-8             294µs ±23%   623µs ± 8%  +111.59%  (p=0.008 n=5+5)
    Scan/warmup_(disregard)_(custom_escapes)-8               294µs ±23%   617µs ± 1%  +109.60%  (p=0.008 n=5+5)
    Scan/no_quotes_(standard_escapes)-8                      273µs ± 2%   625µs ± 2%  +129.08%  (p=0.008 n=5+5)
    Scan/no_quotes_(custom_escapes)-8                        273µs ± 2%   633µs ± 1%  +132.08%  (p=0.008 n=5+5)
    Scan/some_quotes_at_the_beginning_(standard_escapes)-8   281µs ± 6%   835µs ± 2%  +196.96%  (p=0.008 n=5+5)
    Scan/some_quotes_at_the_beginning_(custom_escapes)-8     281µs ± 6%   850µs ± 2%  +202.22%  (p=0.008 n=5+5)
    Scan/some_quotes_in_the_middle_(standard_escapes)-8      280µs ± 5%   856µs ± 2%  +205.66%  (p=0.008 n=5+5)
    Scan/some_quotes_in_the_middle_(custom_escapes)-8        280µs ± 5%   879µs ± 2%  +214.06%  (p=0.008 n=5+5)
    Scan/all_quotes_(standard_escapes)-8                     332µs ±10%  1106µs ± 1%  +232.77%  (p=0.008 n=5+5)
    Scan/all_quotes_(custom_escapes)-8                       332µs ±10%  1129µs ± 2%  +239.91%  (p=0.008 n=5+5)
    Scan/nothing_but_quotes_(standard_escapes)-8             303µs ± 5%   859µs ± 1%  +183.87%  (p=0.008 n=5+5)
    Scan/nothing_but_quotes_(custom_escapes)-8               303µs ± 5%  1140µs ± 1%  +276.61%  (p=0.008 n=5+5)

This is a pretty significant slowdown -- we've reduced the speed by a factor of two or three.