### PR TITLE
Set application_name on Postgres connections

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -45,6 +45,7 @@ func (mcc *minimalConnConfig) DSN() string {
 		writeNonempty("port", strconv.FormatUint(uint64(mcc.port), 10))
 	}
 	writeNonempty("sslmode", mcc.sslmode)
+	writeNonempty("application_name", "timescaledb-parallel-copy")
 
 	return strings.TrimSpace(s.String())
 }

--- a/internal/db/db_internal_test.go
+++ b/internal/db/db_internal_test.go
@@ -193,3 +193,32 @@ func TestDetermineTLS(t *testing.T) {
 		})
 	}
 }
+
+func TestDSN(t *testing.T) {
+	cases := []struct {
+		desc  string
+		input minimalConnConfig
+		want  string
+	}{
+		{
+			desc: "",
+			input: minimalConnConfig{
+				host:     "localhost",
+				port:     5432,
+				user:     "user",
+				password: "password",
+				db:       "db",
+				sslmode:  "prefer",
+			},
+			want: "host=localhost user=user password=password dbname=db port=5432 sslmode=prefer application_name=timescaledb-parallel-copy",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got := c.input.DSN()
+			if c.want != got {
+				t.Errorf("wanted %s got %s", c.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Sets `application_name=timescaledb-parallel-copy` on the Postgres connections.