### PR TITLE
Return error instead of panicking

### DIFF
--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -132,7 +133,7 @@ func main() {
 		reader = os.Stdin
 	}
 
-	result, err := copier.Copy(reader)
+	result, err := copier.Copy(context.Background(), reader)
 	if err != nil {
 		log.Fatal("failed to copy CSV:", err)
 	}

--- a/internal/batch/scan_internal_test.go
+++ b/internal/batch/scan_internal_test.go
@@ -1,6 +1,7 @@
 package batch
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -227,7 +228,7 @@ func TestCSVRowState(t *testing.T) {
 			allLines := strings.Join(c.input, "")
 			copyCmd := fmt.Sprintf(`COPY csv FROM STDIN WITH %s`, copyOpts)
 
-			num, err := db.CopyFromLines(d, strings.NewReader(allLines), copyCmd)
+			num, err := db.CopyFromLines(context.Background(), d, strings.NewReader(allLines), copyCmd)
 
 			if c.expectMore {
 				// If our test case claimed to be unterminated, then the DB

--- a/internal/batch/scan_test.go
+++ b/internal/batch/scan_test.go
@@ -2,6 +2,7 @@ package batch_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -262,7 +263,7 @@ d"
 				Escape: byte(c.escape),
 			}
 
-			err := batch.Scan(reader, rowChan, opts)
+			err := batch.Scan(context.Background(), reader, rowChan, opts)
 			if err != nil {
 				t.Fatalf("Scan() returned error: %v", err)
 			}
@@ -307,7 +308,7 @@ d"
 				Skip: c.skip,
 			}
 
-			err := batch.Scan(reader, rowChan, opts)
+			err := batch.Scan(context.Background(), reader, rowChan, opts)
 			if !errors.Is(err, expected) {
 				t.Errorf("Scan() returned unexpected error: %v", err)
 				t.Logf("want: %v", expected)
@@ -416,7 +417,7 @@ func BenchmarkScan(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					reader.Reset(data) // rewind to the beginning
 
-					err := batch.Scan(reader, rowChan, opts)
+					err := batch.Scan(context.Background(), reader, rowChan, opts)
 					if err != nil {
 						b.Errorf("Scan() returned unexpected error: %v", err)
 					}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -156,8 +156,8 @@ func Connect(connStr string, overrides ...Overrideable) (*sqlx.DB, error) {
 // CopyFromLines bulk-loads data using the given copyCmd. lines must provide a
 // set of complete lines of CSV data, including the end-of-line delimiters.
 // Returns the number of rows inserted.
-func CopyFromLines(db *sqlx.DB, lines io.Reader, copyCmd string) (int64, error) {
-	conn, err := db.Conn(context.Background())
+func CopyFromLines(ctx context.Context, db *sqlx.DB, lines io.Reader, copyCmd string) (int64, error) {
+	conn, err := db.Conn(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("acquiring DB connection for COPY: %w", err)
 	}
@@ -171,7 +171,7 @@ func CopyFromLines(db *sqlx.DB, lines io.Reader, copyCmd string) (int64, error) 
 		// the pgx.Conn, and the pgconn.PgConn.
 		pg := driverConn.(*stdlib.Conn).Conn().PgConn()
 
-		result, err := pg.CopyFrom(context.Background(), lines, copyCmd)
+		result, err := pg.CopyFrom(ctx, lines, copyCmd)
 		if err != nil {
 			return err
 		}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"reflect"
@@ -153,7 +154,7 @@ func TestCopyFromLines(t *testing.T) {
 
 			// Load the rows into it.
 			allLines := strings.Join(append(c.lines, ""), "\n")
-			num, err := db.CopyFromLines(d, strings.NewReader(allLines), c.copyCmd)
+			num, err := db.CopyFromLines(context.Background(), d, strings.NewReader(allLines), c.copyCmd)
 			if err != nil {
 				t.Errorf("CopyFromLines() returned error: %v", err)
 			}
@@ -198,7 +199,7 @@ func TestCopyFromLines(t *testing.T) {
 		lines := bytes.Repeat([]byte{'\n'}, 10000)
 		badCopy := `COPY BUT NOT REALLY`
 
-		num, err := db.CopyFromLines(d, bytes.NewReader(lines), badCopy)
+		num, err := db.CopyFromLines(context.Background(), d, bytes.NewReader(lines), badCopy)
 		if num != 0 {
 			t.Errorf("CopyFromLines() reported %d new rows, want 0", num)
 		}
@@ -249,7 +250,7 @@ func TestCopyFromLines(t *testing.T) {
 		}
 
 		lineData := strings.Join(append(lines, ""), "\n")
-		_, err := db.CopyFromLines(d, strings.NewReader(lineData), cmd)
+		_, err := db.CopyFromLines(context.Background(), d, strings.NewReader(lineData), cmd)
 		if err != nil {
 			t.Fatalf("CopyFromLines() returned error: %v", err)
 		}

--- a/pkg/csvcopy/csvcopy_test.go
+++ b/pkg/csvcopy/csvcopy_test.go
@@ -72,7 +72,7 @@ func TestWriteDataToCSV(t *testing.T) {
 
 	reader, err := os.Open(tmpfile.Name())
 	require.NoError(t, err)
-	r, err := copier.Copy(reader)
+	r, err := copier.Copy(context.Background(), reader)
 	require.NoError(t, err)
 	require.NotNil(t, r)
 


### PR DESCRIPTION
Improve the error handling by actually returning errors from workers instead of panicking. Additionally, Copy now accepts a context that's propagated through the execution and can be cancelled to stop it.