### PR TITLE
Abort when 'HEADERS' passed to -copy-options

### DIFF
--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -110,6 +111,9 @@ func main() {
 		csvcopy.WithLogger(&csvCopierLogger{}),
 	)
 	if err != nil {
+		if errors.Is(err, csvcopy.HeaderInCopyOptionsError) {
+			log.Fatalf("Error: 'HEADER' detected in -copy-options. If you were using 'HEADER' with PostgreSQL COPY, use: -skip-header")
+		}
 		log.Fatal(err)
 	}
 

--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -40,6 +40,8 @@ type Result struct {
 	RowRate  float64
 }
 
+var HeaderInCopyOptionsError = errors.New("'HEADER' in copyOptions")
+
 type Copier struct {
 	dbURL           string
 	overrides       []db.Overrideable
@@ -84,6 +86,10 @@ func NewCopier(
 	var overrides []db.Overrideable
 	if dbName != "" {
 		overrides = append(overrides, db.OverrideDBName(dbName))
+	}
+
+	if strings.Contains(strings.ToUpper(copyOptions), "HEADER") {
+		return nil, HeaderInCopyOptionsError
 	}
 
 	if len(quoteCharacter) > 1 {


### PR DESCRIPTION
Users familiar with loading CSV data with the COPY command know the 'HEADER' option, and erroneously believe that they should use it with timescaledb-parallel-copy (by passing 'CSV HEADER' to -copy-options).

timescaledb-parallel-copy handles this use-case with the -skip-header option. Passing HEADER to -copy-options results in the first row of every _batch_ being discarded, causing silent data loss.

This change is backwards incompatible, because it aborts on inputs which it previously accepted.

We have not provided a way to pass HEADER to -copy-options, because we don't believe that there is a legitimate use-case for this combination.

Fixes: #59