### PR TITLE
Feat: Report line with error

### DIFF
--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -139,7 +139,7 @@ func main() {
 
 	result, err := copier.Copy(context.Background(), reader)
 	if err != nil {
-		log.Fatal("failed to copy CSV:", err)
+		log.Fatal("failed to copy CSV: ", err)
 	}
 
 	res := fmt.Sprintf("COPY %d", result.RowsRead)

--- a/internal/batch/scan.go
+++ b/internal/batch/scan.go
@@ -48,7 +48,6 @@ func Scan(ctx context.Context, r io.Reader, out chan<- Batch, opts Options) erro
 		// The use of ReadLine() here avoids copying or buffering data that
 		// we're just going to discard.
 		_, isPrefix, err := reader.ReadLine()
-		rowsRead++
 
 		if err == io.EOF {
 			// No data?
@@ -128,7 +127,7 @@ func Scan(ctx context.Context, r io.Reader, out chan<- Batch, opts Options) erro
 				case out <- Batch{
 					Data: bufs,
 					Location: Location{
-						StartRow: rowsRead - int64(bufferedRows),
+						StartRow: rowsRead - int64(bufferedRows) + int64(opts.Skip),
 						Length:   bufferedRows,
 					},
 				}:
@@ -154,7 +153,7 @@ func Scan(ctx context.Context, r io.Reader, out chan<- Batch, opts Options) erro
 		case out <- Batch{
 			Data: bufs,
 			Location: Location{
-				StartRow: rowsRead - int64(bufferedRows),
+				StartRow: rowsRead - int64(bufferedRows) + int64(opts.Skip),
 				Length:   bufferedRows,
 			},
 		}:

--- a/internal/batch/scan.go
+++ b/internal/batch/scan.go
@@ -18,6 +18,18 @@ type Options struct {
 	Escape byte // the ESCAPE character; defaults to QUOTE
 }
 
+// Batch represents an operation to copy data into the DB
+type Batch struct {
+	Data     net.Buffers
+	Location Location
+}
+
+// Location positions a batch within the original data
+type Location struct {
+	StartRow int64
+	Length   int
+}
+
 // Scan reads all lines from an io.Reader, partitions them into net.Buffers with
 // opts.Size rows each, and writes each batch to the out channel. If opts.Skip
 // is greater than zero, that number of lines will be discarded from the
@@ -28,7 +40,7 @@ type Options struct {
 // Scan expects the input to be in Postgres CSV format. Since this format allows
 // rows to be split over multiple lines, the caller may provide opts.Quote and
 // opts.Escape as the QUOTE and ESCAPE characters used for the CSV input.
-func Scan(ctx context.Context, r io.Reader, out chan<- net.Buffers, opts Options) error {
+func Scan(ctx context.Context, r io.Reader, out chan<- Batch, opts Options) error {
 	var rowsRead int64
 	reader := bufio.NewReader(r)
 
@@ -36,6 +48,7 @@ func Scan(ctx context.Context, r io.Reader, out chan<- net.Buffers, opts Options
 		// The use of ReadLine() here avoids copying or buffering data that
 		// we're just going to discard.
 		_, isPrefix, err := reader.ReadLine()
+		rowsRead++
 
 		if err == io.EOF {
 			// No data?
@@ -112,7 +125,13 @@ func Scan(ctx context.Context, r io.Reader, out chan<- net.Buffers, opts Options
 
 			if bufferedRows >= opts.Size { // dispatch to COPY worker & reset
 				select {
-				case out <- bufs:
+				case out <- Batch{
+					Data: bufs,
+					Location: Location{
+						StartRow: rowsRead - int64(bufferedRows),
+						Length:   bufferedRows,
+					},
+				}:
 				case <-ctx.Done():
 					return ctx.Err()
 				}
@@ -132,7 +151,13 @@ func Scan(ctx context.Context, r io.Reader, out chan<- net.Buffers, opts Options
 	// Finished reading input, make sure last batch goes out.
 	if len(bufs) > 0 {
 		select {
-		case out <- bufs:
+		case out <- Batch{
+			Data: bufs,
+			Location: Location{
+				StartRow: rowsRead - int64(bufferedRows),
+				Length:   bufferedRows,
+			},
+		}:
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/internal/batch/scan_test.go
+++ b/internal/batch/scan_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"reflect"
 	"strings"
 	"testing"
@@ -239,7 +238,7 @@ d"
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			rowChan := make(chan net.Buffers)
+			rowChan := make(chan batch.Batch)
 			resultChan := make(chan []string)
 
 			// Collector for the scanned row batches.
@@ -247,7 +246,7 @@ d"
 				var actual []string
 
 				for buf := range rowChan {
-					actual = append(actual, string(bytes.Join(buf, nil)))
+					actual = append(actual, string(bytes.Join(buf.Data, nil)))
 				}
 
 				resultChan <- actual
@@ -302,7 +301,7 @@ d"
 				should be discarded
 			`), expected)
 
-			rowChan := make(chan net.Buffers, 1)
+			rowChan := make(chan batch.Batch, 1)
 			opts := batch.Options{
 				Size: 50,
 				Skip: c.skip,
@@ -411,7 +410,7 @@ func BenchmarkScan(b *testing.B) {
 			b.Run(name, func(b *testing.B) {
 				// Make sure our output channel won't block. This relies on each
 				// call to Scan() producing exactly one batch.
-				rowChan := make(chan net.Buffers, b.N)
+				rowChan := make(chan batch.Batch, b.N)
 				b.ResetTimer()
 
 				for i := 0; i < b.N; i++ {

--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -240,7 +240,7 @@ type ErrAtRow struct {
 func ErrAtRowFromPGError(pgerr *pgconn.PgError, offset int64) *ErrAtRow {
 	// Example of Where field
 	// "COPY metrics, line 1, column value: \"hello\""
-	match := regexp.MustCompile("line (\\d+)").FindStringSubmatch(pgerr.Where)
+	match := regexp.MustCompile(`line (\d+)`).FindStringSubmatch(pgerr.Where)
 	if len(match) != 2 {
 		return &ErrAtRow{
 			Err: pgerr,

--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/jackc/pgconn"
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/timescale/timescaledb-parallel-copy/internal/batch"
 	"github.com/timescale/timescaledb-parallel-copy/internal/db"
@@ -161,7 +163,7 @@ func (c *Copier) Truncate() (err error) {
 
 func (c *Copier) Copy(ctx context.Context, reader io.Reader) (Result, error) {
 	var wg sync.WaitGroup
-	batchChan := make(chan net.Buffers, c.workers*2)
+	batchChan := make(chan batch.Batch, c.workers*2)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -230,9 +232,50 @@ func (c *Copier) Copy(ctx context.Context, reader io.Reader) (Result, error) {
 	}, err
 }
 
+type ErrAtRow struct {
+	Err error
+	Row int64
+}
+
+func ErrAtRowFromPGError(pgerr *pgconn.PgError, offset int64) *ErrAtRow {
+	// Example of Where field
+	// "COPY metrics, line 1, column value: \"hello\""
+	match := regexp.MustCompile("line (\\d+)").FindStringSubmatch(pgerr.Where)
+	if len(match) != 2 {
+		return &ErrAtRow{
+			Err: pgerr,
+			Row: -1,
+		}
+	}
+
+	line, err := strconv.Atoi(match[1])
+	if err != nil {
+		return &ErrAtRow{
+			Err: pgerr,
+			Row: -1,
+		}
+	}
+
+	return &ErrAtRow{
+		Err: pgerr,
+		Row: offset + int64(line),
+	}
+}
+
+func (e *ErrAtRow) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("at row %d, error %s", e.Row, e.Err.Error())
+	}
+	return fmt.Sprintf("error at row %d", e.Row)
+}
+
+func (e *ErrAtRow) Unwrap() error {
+	return e.Err
+}
+
 // processBatches reads batches from channel c and copies them to the target
 // server while tracking stats on the write.
-func (c *Copier) processBatches(ctx context.Context, ch chan net.Buffers) (err error) {
+func (c *Copier) processBatches(ctx context.Context, ch chan batch.Batch) (err error) {
 	dbx, err := db.Connect(c.dbURL, c.overrides...)
 	if err != nil {
 		return err
@@ -273,15 +316,18 @@ func (c *Copier) processBatches(ctx context.Context, ch chan net.Buffers) (err e
 				return
 			}
 			start := time.Now()
-			rows, err := db.CopyFromLines(ctx, dbx, &batch, copyCmd)
+			rows, err := db.CopyFromLines(ctx, dbx, &batch.Data, copyCmd)
 			if err != nil {
-				return err
+				if pgerr, ok := err.(*pgconn.PgError); ok {
+					return ErrAtRowFromPGError(pgerr, batch.Location.StartRow)
+				}
+				return fmt.Errorf("[BATCH] starting at row %d: %w", batch.Location.StartRow, err)
 			}
 			atomic.AddInt64(&c.rowCount, rows)
 
 			if c.logBatches {
 				took := time.Since(start)
-				fmt.Printf("[BATCH] took %v, batch size %d, row rate %f/sec\n", took, c.batchSize, float64(c.batchSize)/float64(took.Seconds()))
+				fmt.Printf("[BATCH] starting at row %d, took %v, batch size %d, row rate %f/sec\n", batch.Location.StartRow, took, batch.Location.Length, float64(batch.Location.Length)/float64(took.Seconds()))
 			}
 		}
 	}

--- a/pkg/csvcopy/csvcopy_test.go
+++ b/pkg/csvcopy/csvcopy_test.go
@@ -97,3 +97,69 @@ func TestWriteDataToCSV(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []interface{}{int32(24), "qased", 2.4}, results)
 }
+
+func TestErrorAtRow(t *testing.T) {
+	ctx := context.Background()
+
+	pgContainer, err := postgres.RunContainer(ctx,
+		testcontainers.WithImage("postgres:15.3-alpine"),
+		postgres.WithDatabase("test-db"),
+		postgres.WithUsername("postgres"),
+		postgres.WithPassword("postgres"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(5*time.Second)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if err := pgContainer.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate pgContainer: %s", err)
+		}
+	})
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+	_, err = conn.Exec(ctx, "create table public.metrics (device_id int, label text, value float8)")
+	require.NoError(t, err)
+
+	// Create a temporary CSV file
+	tmpfile, err := os.CreateTemp("", "example")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	// Write data to the CSV file
+	writer := csv.NewWriter(tmpfile)
+
+	data := [][]string{
+		{"42", "xasev", "4.2"},
+		{"24", "qased", "2.4"},
+		{"24", "qased", "2.4"},
+		{"24", "qased", "hello"},
+		{"24", "qased", "2.4"},
+		{"24", "qased", "2.4"},
+	}
+
+	for _, record := range data {
+		if err := writer.Write(record); err != nil {
+			t.Fatalf("Error writing record to CSV: %v", err)
+		}
+	}
+
+	writer.Flush()
+
+	copier, err := NewCopier(connStr, "test-db", "public", "metrics", "CSV", ",", "", "", "device_id,label,value", false, 1, 1, 0, 2, true, 0, false)
+	require.NoError(t, err)
+	reader, err := os.Open(tmpfile.Name())
+	require.NoError(t, err)
+	_, err = copier.Copy(context.Background(), reader)
+	assert.Error(t, err)
+	assert.IsType(t, err, &ErrAtRow{})
+	assert.EqualValues(t, 4, err.(*ErrAtRow).Row)
+}


### PR DESCRIPTION
I've been trying to import data multiple times just to get an error half way on the process and with no trace of where to look to fix it.

This implementation attempts to capture such errors and generate a meaningful error message.


## Before

```
$ timescaledb-parallel-copy --batch-size 2000 -columns timestamp,email,product_name,product_price,product_description,address -connection "postgres://tsdbadmin@dg7cvr30ww.xltbtwir0g.dev.metronome-cloud.com:30672/tsdb?sslmode=require" -file bad-250Mb.csv -log-batches --skip-header -workers 1 -table products -verbose -truncate
Skipping the first 1 lines of the input.
[BATCH] took 567.961244ms, batch size 2000, row rate 3521.367032/sec
[BATCH] took 125.747937ms, batch size 2000, row rate 15904.833492/sec
[BATCH] took 139.151848ms, batch size 2000, row rate 14372.787920/sec
[BATCH] took 142.811386ms, batch size 2000, row rate 14004.485609/sec
[BATCH] took 112.891626ms, batch size 2000, row rate 17716.105887/sec
[BATCH] took 186.054276ms, batch size 2000, row rate 10749.551384/sec
[BATCH] took 113.177297ms, batch size 2000, row rate 17671.388635/sec
[BATCH] took 123.797261ms, batch size 2000, row rate 16155.446282/sec
[BATCH] took 111.88454ms, batch size 2000, row rate 17875.570655/sec
[BATCH] took 107.85928ms, batch size 2000, row rate 18542.678942/sec
[BATCH] took 111.215041ms, batch size 2000, row rate 17983.179092/sec
[BATCH] took 184.479565ms, batch size 2000, row rate 10841.309172/sec
[BATCH] took 122.392409ms, batch size 2000, row rate 16340.882709/sec
[BATCH] took 141.059528ms, batch size 2000, row rate 14178.411259/sec
[BATCH] took 123.626816ms, batch size 2000, row rate 16177.719889/sec
[BATCH] took 116.044467ms, batch size 2000, row rate 17234.772598/sec
[BATCH] took 112.695756ms, batch size 2000, row rate 17746.897230/sec
[BATCH] took 114.721243ms, batch size 2000, row rate 17433.562849/sec
[BATCH] took 109.253479ms, batch size 2000, row rate 18306.053210/sec
[BATCH] took 121.582399ms, batch size 2000, row rate 16449.749441/sec
[BATCH] took 199.260791ms, batch size 2000, row rate 10037.097564/sec
[BATCH] took 197.938016ms, batch size 2000, row rate 10104.173218/sec
[BATCH] took 156.753388ms, batch size 2000, row rate 12758.894883/sec
[BATCH] took 334.371066ms, batch size 2000, row rate 5981.378784/sec
[BATCH] took 150.12141ms, batch size 2000, row rate 13322.550061/sec
[BATCH] took 174.82346ms, batch size 2000, row rate 11440.112214/sec
[BATCH] took 170.614888ms, batch size 2000, row rate 11722.306438/sec
[BATCH] took 118.299331ms, batch size 2000, row rate 16906.266359/sec
[BATCH] took 128.944185ms, batch size 2000, row rate 15510.587003/sec
[BATCH] took 116.72739ms, batch size 2000, row rate 17133.939172/sec
[BATCH] took 193.770443ms, batch size 2000, row rate 10321.491601/sec
[BATCH] took 115.494272ms, batch size 2000, row rate 17316.876113/sec
[BATCH] took 114.99559ms, batch size 2000, row rate 17391.971292/sec
2024/11/08 11:21:14 failed to copy CSV:ERROR: invalid input syntax for type timestamp with time zone: "2024-02-16T07:04:00ZXXXXX" (SQLSTATE 22007)

```


## After

```
$ timescaledb-parallel-copy --batch-size 2000 -columns timestamp,email,product_name,product_price,product_description,address -connection "postgres://tsdbadmin@dg7cvr30ww.xltbtwir0g.dev.metronome-cloud.com:30672/tsdb?sslmode=require" -file bad-250Mb.csv -log-batches --skip-header -workers 1 -table products -verbose -truncate
Skipping the first 1 lines of the input.
[BATCH] starting at row 1, took 606.668007ms, batch size 2000, row rate 3296.696013/sec
[BATCH] starting at row 2001, took 236.981362ms, batch size 2000, row rate 8439.482258/sec
[BATCH] starting at row 4001, took 118.196948ms, batch size 2000, row rate 16920.910682/sec
[BATCH] starting at row 6001, took 108.360958ms, batch size 2000, row rate 18456.832026/sec
[BATCH] starting at row 8001, took 134.771192ms, batch size 2000, row rate 14839.966690/sec
[BATCH] starting at row 10001, took 118.739019ms, batch size 2000, row rate 16843.662823/sec
[BATCH] starting at row 12001, took 112.223845ms, batch size 2000, row rate 17821.524472/sec
[BATCH] starting at row 14001, took 108.750066ms, batch size 2000, row rate 18390.793436/sec
[BATCH] starting at row 16001, took 109.593439ms, batch size 2000, row rate 18249.267641/sec
[BATCH] starting at row 18001, took 111.232952ms, batch size 2000, row rate 17980.283397/sec
[BATCH] starting at row 20001, took 169.320067ms, batch size 2000, row rate 11811.949023/sec
[BATCH] starting at row 22001, took 113.590304ms, batch size 2000, row rate 17607.136609/sec
[BATCH] starting at row 24001, took 120.835396ms, batch size 2000, row rate 16551.441599/sec
[BATCH] starting at row 26001, took 136.997882ms, batch size 2000, row rate 14598.765841/sec
[BATCH] starting at row 28001, took 113.137801ms, batch size 2000, row rate 17677.557654/sec
[BATCH] starting at row 30001, took 110.473816ms, batch size 2000, row rate 18103.837384/sec
[BATCH] starting at row 32001, took 111.76181ms, batch size 2000, row rate 17895.200516/sec
[BATCH] starting at row 34001, took 118.107806ms, batch size 2000, row rate 16933.681759/sec
[BATCH] starting at row 36001, took 119.633148ms, batch size 2000, row rate 16717.774575/sec
[BATCH] starting at row 38001, took 109.157111ms, batch size 2000, row rate 18322.214482/sec
[BATCH] starting at row 40001, took 115.062918ms, batch size 2000, row rate 17381.794541/sec
[BATCH] starting at row 42001, took 116.34654ms, batch size 2000, row rate 17190.025591/sec
[BATCH] starting at row 44001, took 110.09867ms, batch size 2000, row rate 18165.523707/sec
[BATCH] starting at row 46001, took 137.654593ms, batch size 2000, row rate 14529.119272/sec
[BATCH] starting at row 48001, took 118.480207ms, batch size 2000, row rate 16880.456666/sec
[BATCH] starting at row 50001, took 176.979979ms, batch size 2000, row rate 11300.713286/sec
[BATCH] starting at row 52001, took 137.458536ms, batch size 2000, row rate 14549.842143/sec
[BATCH] starting at row 54001, took 112.286856ms, batch size 2000, row rate 17811.523728/sec
[BATCH] starting at row 56001, took 118.057313ms, batch size 2000, row rate 16940.924278/sec
[BATCH] starting at row 58001, took 107.700038ms, batch size 2000, row rate 18570.095583/sec
[BATCH] starting at row 60001, took 112.653226ms, batch size 2000, row rate 17753.597221/sec
[BATCH] starting at row 62001, took 117.655682ms, batch size 2000, row rate 16998.754042/sec
[BATCH] starting at row 64001, took 106.193157ms, batch size 2000, row rate 18833.605258/sec
2024/11/08 11:19:58 failed to copy CSV: at row 66666, error ERROR: invalid input syntax for type timestamp with time zone: "2024-02-16T07:04:00ZXXXXX" (SQLSTATE 22007)
```