### PR TITLE
Fix race condition on waiting for progress report to finish

### DIFF
--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -200,7 +200,11 @@ func (c *Copier) Copy(ctx context.Context, reader io.Reader) (Result, error) {
 	// Reporting thread
 	if c.reportingPeriod > (0 * time.Second) {
 		c.logger.Infof("There will be reports every %s", c.reportingPeriod.String())
-		go c.report(ctx)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.report(ctx)
+		}()
 	}
 
 	opts := batch.Options{


### PR DESCRIPTION
What happens is that on close is not waiting for the goroutine to
finish, which leads to inconsistent progress reports.

This change makes sure the goroutine is part of the wait group
