### PR TITLE
Fix dead-lock on progress report

### DIFF
--- a/pkg/csvcopy/csvcopy_test.go
+++ b/pkg/csvcopy/csvcopy_test.go
@@ -163,3 +163,94 @@ func TestErrorAtRow(t *testing.T) {
 	assert.IsType(t, err, &ErrAtRow{})
 	assert.EqualValues(t, 4, err.(*ErrAtRow).Row)
 }
+
+func TestWriteReportProgress(t *testing.T) {
+	ctx := context.Background()
+
+	pgContainer, err := postgres.RunContainer(ctx,
+		testcontainers.WithImage("postgres:15.3-alpine"),
+		postgres.WithDatabase("test-db"),
+		postgres.WithUsername("postgres"),
+		postgres.WithPassword("postgres"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(5*time.Second)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if err := pgContainer.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate pgContainer: %s", err)
+		}
+	})
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+	_, err = conn.Exec(ctx, "create table public.metrics (device_id int, label text, value float8)")
+	require.NoError(t, err)
+
+	// Create a temporary CSV file
+	tmpfile, err := os.CreateTemp("", "example")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	// Write data to the CSV file
+	writer := csv.NewWriter(tmpfile)
+
+	data := [][]string{
+		{"42", "xasev", "4.2"},
+		{"24", "qased", "2.4"},
+	}
+
+	for _, record := range data {
+		if err := writer.Write(record); err != nil {
+			t.Fatalf("Error writing record to CSV: %v", err)
+		}
+	}
+
+	writer.Flush()
+	atLeastOneReport := false
+	reportF := func(r Report) {
+		atLeastOneReport = true
+		require.GreaterOrEqual(t, r.RowCount, int64(0))
+		require.LessOrEqual(t, r.RowCount, int64(2))
+	}
+
+	copier, err := NewCopier(connStr, "test-db", "public", "metrics", "CSV", ",", "", "", "device_id,label,value", false, 1, 1, 0, 5000, true, 100*time.Millisecond, false, WithReportingFunction(reportF))
+	require.NoError(t, err)
+
+	reader, err := os.Open(tmpfile.Name())
+	require.NoError(t, err)
+	r, err := copier.Copy(context.Background(), reader)
+	require.NoError(t, err)
+	require.NotNil(t, r)
+
+	require.True(t, atLeastOneReport)
+
+	var rowCount int64
+	err = conn.QueryRow(ctx, "select count(*) from public.metrics").Scan(&rowCount)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), rowCount)
+	assert.Equal(t, int64(2), copier.GetRowCount())
+
+	rows, err := conn.Query(ctx, "select * from public.metrics")
+	require.NoError(t, err)
+
+	hasNext := rows.Next()
+	require.True(t, hasNext)
+	results, err := rows.Values()
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{int32(42), "xasev", 4.2}, results)
+
+	hasNext = rows.Next()
+	require.True(t, hasNext)
+	results, err = rows.Values()
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{int32(24), "qased", 2.4}, results)
+}


### PR DESCRIPTION
Dead lock happen because the worker wait group was shared with the support tasks. 
This attempts to separate both processes and make sure all workers finish before the support tasks are stopped