### PR TITLE
Fix race condition on worker failure

### DIFF
--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -161,7 +161,9 @@ func (c *Copier) Copy(ctx context.Context, reader io.Reader) (Result, error) {
 	}
 
 	start := time.Now()
+	workerWg.Add(1)
 	go func() {
+		defer workerWg.Done()
 		if err := batch.Scan(ctx, reader, batchChan, opts); err != nil {
 			errCh <- fmt.Errorf("failed reading input: %w", err)
 			cancel()


### PR DESCRIPTION
If a worker fails, the context is cancelled, this leads to all workers+the scanner stopping immediately.

The race conditions happens because if all the workers close before the scanner, the code will proceed and close the error channel. Then the scanner fails when attempting to publish to the error channel.

This is solved by adding the scanner to the worker group. this will make sure we always wait for all goroutines that publish to errCh to stop
