### PR TITLE
Fix WithSkipHeader package option

### DIFF
--- a/pkg/csvcopy/options.go
+++ b/pkg/csvcopy/options.go
@@ -113,7 +113,9 @@ func WithSkipHeader(skipHeader bool) Option {
 		if c.skip != 0 {
 			return errors.New("skip is already set. Use SkipHeader or SkipHeaderCount")
 		}
-		c.skip = 1
+		if skipHeader {
+			c.skip = 1
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
The option has a boolean flag that was not being used. 

This fixes the problem by making sure the skip is set to 1 when the value is true
