### PR TITLE
feat: column mapping and auto column mapping

### DIFF
--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/timescale/timescaledb-parallel-copy/pkg/csvcopy"
@@ -35,6 +37,8 @@ var (
 
 	fromFile        string
 	columns         string
+	columnMapping   string
+	autoColumnMapping bool
 	skipHeader      bool
 	headerLinesCnt  int
 	skipBatchErrors bool
@@ -68,6 +72,8 @@ func init() {
 	flag.StringVar(&escapeCharacter, "escape", "", "The ESCAPE `character` to use during COPY (default '\"')")
 	flag.StringVar(&fromFile, "file", "", "File to read from rather than stdin")
 	flag.StringVar(&columns, "columns", "", "Comma-separated columns present in CSV")
+	flag.StringVar(&columnMapping, "column-mapping", "", "Column mapping from CSV to database columns (format: \"csv_col1:db_col1,csv_col2:db_col2\" or JSON)")
+	flag.BoolVar(&autoColumnMapping, "auto-column-mapping", false, "Automatically map CSV headers to database columns with the same names")
 	flag.BoolVar(&skipHeader, "skip-header", false, "Skip the first line of the input")
 	flag.IntVar(&headerLinesCnt, "header-line-count", 1, "Number of header lines")
 
@@ -125,6 +131,18 @@ func main() {
 
 	if importID != "" {
 		opts = append(opts, csvcopy.WithImportID(importID))
+	}
+
+	if columnMapping != "" {
+		mapping, err := parseColumnMapping(columnMapping)
+		if err != nil {
+			log.Fatalf("Error parsing column mapping: %v", err)
+		}
+		opts = append(opts, csvcopy.WithColumnMapping(mapping))
+	}
+
+	if autoColumnMapping {
+		opts = append(opts, csvcopy.WithAutoColumnMapping())
 	}
 
 	batchErrorHandler := csvcopy.BatchHandlerError()
@@ -189,4 +207,74 @@ func main() {
 		)
 	}
 	fmt.Println(res)
+}
+
+// parseColumnMapping parses column mapping string into csvcopy.ColumnsMapping
+// Supports two formats:
+// 1. Simple: "csv_col1:db_col1,csv_col2:db_col2"
+// 2. JSON: {"csv_col1":"db_col1","csv_col2":"db_col2"}
+func parseColumnMapping(mappingStr string) (csvcopy.ColumnsMapping, error) {
+	if mappingStr == "" {
+		return nil, nil
+	}
+
+	mappingStr = strings.TrimSpace(mappingStr)
+
+	// Check if it's JSON format (starts with '{')
+	if strings.HasPrefix(mappingStr, "{") {
+		return parseJSONColumnMapping(mappingStr)
+	}
+
+	// Parse simple format: "csv_col1:db_col1,csv_col2:db_col2"
+	return parseSimpleColumnMapping(mappingStr)
+}
+
+// parseJSONColumnMapping parses JSON format column mapping
+func parseJSONColumnMapping(jsonStr string) (csvcopy.ColumnsMapping, error) {
+	var mappingMap map[string]string
+	if err := json.Unmarshal([]byte(jsonStr), &mappingMap); err != nil {
+		return nil, fmt.Errorf("invalid JSON format for column mapping: %w", err)
+	}
+
+	var mapping csvcopy.ColumnsMapping
+	for csvCol, dbCol := range mappingMap {
+		mapping = append(mapping, csvcopy.ColumnMapping{
+			CSVColumnName:      csvCol,
+			DatabaseColumnName: dbCol,
+		})
+	}
+
+	return mapping, nil
+}
+
+// parseSimpleColumnMapping parses simple format: "csv_col1:db_col1,csv_col2:db_col2"
+func parseSimpleColumnMapping(simpleStr string) (csvcopy.ColumnsMapping, error) {
+	pairs := strings.Split(simpleStr, ",")
+	var mapping csvcopy.ColumnsMapping
+
+	for i, pair := range pairs {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+
+		parts := strings.Split(pair, ":")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid column mapping format at position %d: '%s', expected 'csv_column:db_column'", i+1, pair)
+		}
+
+		csvCol := strings.TrimSpace(parts[0])
+		dbCol := strings.TrimSpace(parts[1])
+
+		if csvCol == "" || dbCol == "" {
+			return nil, fmt.Errorf("empty column name in mapping at position %d: '%s'", i+1, pair)
+		}
+
+		mapping = append(mapping, csvcopy.ColumnMapping{
+			CSVColumnName:      csvCol,
+			DatabaseColumnName: dbCol,
+		})
+	}
+
+	return mapping, nil
 }

--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -35,13 +35,13 @@ var (
 	quoteCharacter  string
 	escapeCharacter string
 
-	fromFile        string
-	columns         string
-	columnMapping   string
+	fromFile          string
+	columns           string
+	columnMapping     string
 	autoColumnMapping bool
-	skipHeader      bool
-	headerLinesCnt  int
-	skipBatchErrors bool
+	skipHeader        bool
+	headerLinesCnt    int
+	skipBatchErrors   bool
 
 	importID        string
 	workers         int
@@ -74,6 +74,9 @@ func init() {
 	flag.StringVar(&columns, "columns", "", "Comma-separated columns present in CSV")
 	flag.StringVar(&columnMapping, "column-mapping", "", "Column mapping from CSV to database columns (format: \"csv_col1:db_col1,csv_col2:db_col2\" or JSON)")
 	flag.BoolVar(&autoColumnMapping, "auto-column-mapping", false, "Automatically map CSV headers to database columns with the same names")
+
+	// TODO The point is that we talk about "header" line(s) in the context of CSV files, but we are just skipping the first line(s) of the input.
+	// So this flag should be renamed to something like "skip-first-line(s)".
 	flag.BoolVar(&skipHeader, "skip-header", false, "Skip the first line of the input")
 	flag.IntVar(&headerLinesCnt, "header-line-count", 1, "Number of header lines")
 

--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -75,8 +75,6 @@ func init() {
 	flag.StringVar(&columnMapping, "column-mapping", "", "Column mapping from CSV to database columns (format: \"csv_col1:db_col1,csv_col2:db_col2\" or JSON)")
 	flag.BoolVar(&autoColumnMapping, "auto-column-mapping", false, "Automatically map CSV headers to database columns with the same names")
 
-	// TODO The point is that we talk about "header" line(s) in the context of CSV files, but we are just skipping the first line(s) of the input.
-	// So this flag should be renamed to something like "skip-first-line(s)".
 	flag.BoolVar(&skipHeader, "skip-header", false, "Skip the first line of the input")
 	flag.IntVar(&headerLinesCnt, "header-line-count", 1, "Number of header lines")
 

--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -156,9 +156,11 @@ func main() {
 	opts = append(opts, csvcopy.WithBatchErrorHandler(batchErrorHandler))
 
 	if skipHeader {
-		opts = append(opts,
-			csvcopy.WithSkipHeaderCount(headerLinesCnt),
-		)
+		if headerLinesCnt == 1 {
+			opts = append(opts, csvcopy.WithSkipHeader(true))
+		} else {
+			opts = append(opts, csvcopy.WithSkipHeaderCount(headerLinesCnt))
+		}
 	}
 
 	copier, err := csvcopy.NewCopier(

--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -160,6 +160,8 @@ func (c *Copier) Copy(ctx context.Context, reader io.Reader) (Result, error) {
 	}
 
 	if c.useColumnMapping {
+		// Increment number of skipped lines to account for the header line
+		c.skip++
 		if err := c.calculateColumnsFromHeaders(bufferedReader); err != nil {
 			return Result{}, fmt.Errorf("failed to calculate columns from headers: %w", err)
 		}

--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -20,6 +20,15 @@ import (
 
 const TAB_CHAR_STR = "\\t"
 
+type HeaderHandling int
+
+const (
+	HeaderNone HeaderHandling = iota
+	HeaderSkip
+	HeaderAutoColumnMapping
+	HeaderColumnMapping
+)
+
 type Result struct {
 	// InsertedRows is the number of rows inserted into the database by this copier instance
 	InsertedRows int64
@@ -57,7 +66,7 @@ type Copier struct {
 	importID          string
 	idempotencyWindow time.Duration
 	columnMapping     ColumnsMapping
-	useColumnMapping  bool
+	useFileHeaders    HeaderHandling
 
 	// Rows that are inserted in the database by this copier instance
 	insertedRows int64
@@ -159,7 +168,7 @@ func (c *Copier) Copy(ctx context.Context, reader io.Reader) (Result, error) {
 		}
 	}
 
-	if c.useColumnMapping {
+	if c.useFileHeaders == HeaderAutoColumnMapping || c.useFileHeaders == HeaderColumnMapping {
 		// Increment number of skipped lines to account for the header line
 		c.skip++
 		if err := c.calculateColumnsFromHeaders(bufferedReader); err != nil {

--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -287,7 +287,7 @@ func (c *Copier) calculateColumnsFromHeaders(bufferedReader *bufio.Reader) error
 		comma = rune(c.splitCharacter[0])
 	}
 
-	headers, err := parseHeaders(bufferedReader, c.skip, quote, escape, comma)
+	headers, err := parseHeaders(bufferedReader, quote, escape, comma)
 	if err != nil {
 		return fmt.Errorf("failed to parse headers: %w", err)
 	}

--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -159,7 +159,10 @@ func (c *Copier) Copy(ctx context.Context, reader io.Reader) (Result, error) {
 		if c.skip != 1 {
 			return Result{}, fmt.Errorf("column mapping requires skip to be exactly 1 (one header row)")
 		}
-		c.calculateColumnsFromHeaders(bufferedReader)
+		err := c.calculateColumnsFromHeaders(bufferedReader)
+		if err != nil {
+			return Result{}, fmt.Errorf("failed to calculate columns from headers: %w", err)
+		}
 	case c.skip > 0:
 		// Just skip headers
 		err := skipHeaders(bufferedReader, c.skip)

--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -30,7 +30,6 @@ const (
 	HeaderColumnMapping
 )
 
-
 type Result struct {
 	// InsertedRows is the number of rows inserted into the database by this copier instance
 	InsertedRows int64
@@ -163,6 +162,10 @@ func (c *Copier) Copy(ctx context.Context, reader io.Reader) (Result, error) {
 
 	counter := &CountReader{Reader: reader}
 	bufferedReader := bufio.NewReaderSize(counter, bufferSize)
+
+	if c.useFileHeaders != HeaderSkip {
+		c.skip++
+	}
 
 	if c.skip > 0 {
 		if err := skipLines(bufferedReader, c.skip); err != nil {

--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -163,7 +163,7 @@ func (c *Copier) Copy(ctx context.Context, reader io.Reader) (Result, error) {
 	counter := &CountReader{Reader: reader}
 	bufferedReader := bufio.NewReaderSize(counter, bufferSize)
 
-	if c.useFileHeaders != HeaderSkip {
+	if c.useFileHeaders == HeaderSkip {
 		c.skip++
 	}
 

--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -57,6 +57,7 @@ type Copier struct {
 	importID          string
 	idempotencyWindow time.Duration
 	columnMapping     ColumnsMapping
+	useColumnMapping  bool
 
 	// Rows that are inserted in the database by this copier instance
 	insertedRows int64
@@ -154,7 +155,7 @@ func (c *Copier) Copy(ctx context.Context, reader io.Reader) (Result, error) {
 	bufferedReader := bufio.NewReaderSize(counter, bufferSize)
 
 	switch {
-	case len(c.columnMapping) > 0:
+	case c.useColumnMapping:
 		if c.skip != 1 {
 			return Result{}, fmt.Errorf("column mapping requires skip to be exactly 1 (one header row)")
 		}
@@ -290,7 +291,7 @@ func (c *Copier) calculateColumnsFromHeaders(bufferedReader *bufio.Reader) error
 
 	if len(c.columnMapping) == 0 {
 		c.columns = strings.Join(headers, ",")
-		c.logger.Infof("No column mapping provided, using all headers: %v", headers)
+		c.logger.Infof("automatic column mapping: %s", c.columns)
 		return nil
 	}
 
@@ -303,7 +304,7 @@ func (c *Copier) calculateColumnsFromHeaders(bufferedReader *bufio.Reader) error
 		columns = append(columns, dbColumn)
 	}
 	c.columns = strings.Join(columns, ",")
-	c.logger.Infof("Using column mapping: %v", c.columns)
+	c.logger.Infof("Using column mapping: %s", c.columns)
 	return nil
 }
 

--- a/pkg/csvcopy/csvcopy_test.go
+++ b/pkg/csvcopy/csvcopy_test.go
@@ -1707,7 +1707,7 @@ func TestCalculateColumnsFromHeaders(t *testing.T) {
 				{CSVColumnName: "full_name", DatabaseColumnName: "name"},
 				{CSVColumnName: "email_address", DatabaseColumnName: "email"},
 			},
-			expectedColumns: "id,name,email",
+			expectedColumns: "\"id\",\"name\",\"email\"",
 		},
 		{
 			name:       "partial mapping",
@@ -1727,7 +1727,7 @@ func TestCalculateColumnsFromHeaders(t *testing.T) {
 				{CSVColumnName: "full name", DatabaseColumnName: "name"},
 				{CSVColumnName: "email address", DatabaseColumnName: "email"},
 			},
-			expectedColumns: "id,name,email",
+			expectedColumns: "\"id\",\"name\",\"email\"",
 		},
 		{
 			name:       "headers with spaces (no quotes)",
@@ -1737,7 +1737,7 @@ func TestCalculateColumnsFromHeaders(t *testing.T) {
 				{CSVColumnName: "full name", DatabaseColumnName: "name"},
 				{CSVColumnName: "email address", DatabaseColumnName: "email"},
 			},
-			expectedColumns: "id,name,email",
+			expectedColumns: "\"id\",\"name\",\"email\"",
 		},
 		{
 			name:       "empty header",
@@ -1747,7 +1747,7 @@ func TestCalculateColumnsFromHeaders(t *testing.T) {
 				{CSVColumnName: "", DatabaseColumnName: "middle_col"},
 				{CSVColumnName: "email", DatabaseColumnName: "email_addr"},
 			},
-			expectedColumns: "user_id,middle_col,email_addr",
+			expectedColumns: "\"user_id\",\"middle_col\",\"email_addr\"",
 		},
 		{
 			name:       "single column",
@@ -1755,7 +1755,7 @@ func TestCalculateColumnsFromHeaders(t *testing.T) {
 			columnMapping: []ColumnMapping{
 				{CSVColumnName: "id", DatabaseColumnName: "user_id"},
 			},
-			expectedColumns: "user_id",
+			expectedColumns: "\"user_id\"",
 		},
 		{
 			name:       "complex quoted headers with commas",
@@ -1765,7 +1765,7 @@ func TestCalculateColumnsFromHeaders(t *testing.T) {
 				{CSVColumnName: "full,name", DatabaseColumnName: "name"},
 				{CSVColumnName: "email,address", DatabaseColumnName: "email"},
 			},
-			expectedColumns: "id,name,email",
+			expectedColumns: "\"id\",\"name\",\"email\"",
 		},
 		{
 			name:            "custom quote character",
@@ -1777,7 +1777,7 @@ func TestCalculateColumnsFromHeaders(t *testing.T) {
 				{CSVColumnName: "full name", DatabaseColumnName: "name"},
 				{CSVColumnName: "email address", DatabaseColumnName: "email"},
 			},
-			expectedColumns: "id,name,email",
+			expectedColumns: "\"id\",\"name\",\"email\"",
 		},
 		{
 			name:       "case sensitive mapping",
@@ -1797,13 +1797,13 @@ func TestCalculateColumnsFromHeaders(t *testing.T) {
 				{CSVColumnName: "name", DatabaseColumnName: "full_name"},
 				{CSVColumnName: "email", DatabaseColumnName: "email_addr"},
 			},
-			expectedColumns: "email_addr,user_id,full_name",
+			expectedColumns: "\"email_addr\",\"user_id\",\"full_name\"",
 		},
 		{
 			name:            "no column mapping - use all headers",
 			csvHeaders:      `"user id","full name","email address"`,
 			columnMapping:   []ColumnMapping{}, // Empty mapping - triggers "No column mapping provided" log
-			expectedColumns: "user id,full name,email address",
+			expectedColumns: "\"user id\",\"full name\",\"email address\"",
 		},
 	}
 
@@ -1855,7 +1855,7 @@ func TestCalculateColumnsFromHeaders_NoMapping(t *testing.T) {
 	err := copier.calculateColumnsFromHeaders(bufferedReader)
 
 	require.NoError(t, err)
-	assert.Equal(t, "id,name,email", copier.columns)
+	assert.Equal(t, "\"id\",\"name\",\"email\"", copier.columns)
 }
 
 func TestColumnsMapping_Get(t *testing.T) {

--- a/pkg/csvcopy/csvcopy_test.go
+++ b/pkg/csvcopy/csvcopy_test.go
@@ -1,10 +1,12 @@
 package csvcopy
 
 import (
+	"bufio"
 	"context"
 	"encoding/csv"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -1424,4 +1426,227 @@ func TestTransactionFailureRetry(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 4, total)
 	})
+}
+
+func TestCalculateColumnsFromHeaders(t *testing.T) {
+	tests := []struct {
+		name            string
+		csvHeaders      string
+		columnMapping   []ColumnMapping
+		quoteCharacter  string
+		escapeCharacter string
+		expectedColumns string
+		expectedError   string
+	}{
+		{
+			name:       "simple mapping",
+			csvHeaders: "user_id,full_name,email_address",
+			columnMapping: []ColumnMapping{
+				{CSVColumnName: "user_id", DatabaseColumnName: "id"},
+				{CSVColumnName: "full_name", DatabaseColumnName: "name"},
+				{CSVColumnName: "email_address", DatabaseColumnName: "email"},
+			},
+			expectedColumns: "id,name,email",
+		},
+		{
+			name:       "partial mapping",
+			csvHeaders: "id,name,age,email",
+			columnMapping: []ColumnMapping{
+				{CSVColumnName: "id", DatabaseColumnName: "user_id"},
+				{CSVColumnName: "name", DatabaseColumnName: "full_name"},
+				{CSVColumnName: "email", DatabaseColumnName: "email_addr"},
+			},
+			expectedError: "column mapping not found for header age",
+		},
+		{
+			name:       "quoted headers",
+			csvHeaders: `"user id","full name","email address"`,
+			columnMapping: []ColumnMapping{
+				{CSVColumnName: "user id", DatabaseColumnName: "id"},
+				{CSVColumnName: "full name", DatabaseColumnName: "name"},
+				{CSVColumnName: "email address", DatabaseColumnName: "email"},
+			},
+			expectedColumns: "id,name,email",
+		},
+		{
+			name:       "headers with spaces (no quotes)",
+			csvHeaders: "user id,full name,email address",
+			columnMapping: []ColumnMapping{
+				{CSVColumnName: "user id", DatabaseColumnName: "id"},
+				{CSVColumnName: "full name", DatabaseColumnName: "name"},
+				{CSVColumnName: "email address", DatabaseColumnName: "email"},
+			},
+			expectedColumns: "id,name,email",
+		},
+		{
+			name:       "empty header",
+			csvHeaders: "id,,email",
+			columnMapping: []ColumnMapping{
+				{CSVColumnName: "id", DatabaseColumnName: "user_id"},
+				{CSVColumnName: "", DatabaseColumnName: "middle_col"},
+				{CSVColumnName: "email", DatabaseColumnName: "email_addr"},
+			},
+			expectedColumns: "user_id,middle_col,email_addr",
+		},
+		{
+			name:       "single column",
+			csvHeaders: "id",
+			columnMapping: []ColumnMapping{
+				{CSVColumnName: "id", DatabaseColumnName: "user_id"},
+			},
+			expectedColumns: "user_id",
+		},
+		{
+			name:       "complex quoted headers with commas",
+			csvHeaders: `"user,id","full,name","email,address"`,
+			columnMapping: []ColumnMapping{
+				{CSVColumnName: "user,id", DatabaseColumnName: "id"},
+				{CSVColumnName: "full,name", DatabaseColumnName: "name"},
+				{CSVColumnName: "email,address", DatabaseColumnName: "email"},
+			},
+			expectedColumns: "id,name,email",
+		},
+		{
+			name:            "custom quote character",
+			csvHeaders:      "'user id','full name','email address'",
+			quoteCharacter:  "'",
+			escapeCharacter: "'",
+			columnMapping: []ColumnMapping{
+				{CSVColumnName: "user id", DatabaseColumnName: "id"},
+				{CSVColumnName: "full name", DatabaseColumnName: "name"},
+				{CSVColumnName: "email address", DatabaseColumnName: "email"},
+			},
+			expectedColumns: "id,name,email",
+		},
+		{
+			name:       "case sensitive mapping",
+			csvHeaders: "ID,Name,Email",
+			columnMapping: []ColumnMapping{
+				{CSVColumnName: "id", DatabaseColumnName: "user_id"},
+				{CSVColumnName: "Name", DatabaseColumnName: "full_name"},
+				{CSVColumnName: "Email", DatabaseColumnName: "email_addr"},
+			},
+			expectedError: "column mapping not found for header ID",
+		},
+		{
+			name:       "order preservation",
+			csvHeaders: "email,id,name",
+			columnMapping: []ColumnMapping{
+				{CSVColumnName: "id", DatabaseColumnName: "user_id"},
+				{CSVColumnName: "name", DatabaseColumnName: "full_name"},
+				{CSVColumnName: "email", DatabaseColumnName: "email_addr"},
+			},
+			expectedColumns: "email_addr,user_id,full_name",
+		},
+		{
+			name:            "no column mapping - use all headers",
+			csvHeaders:      `"user id","full name","email address"`,
+			columnMapping:   []ColumnMapping{}, // Empty mapping - triggers "No column mapping provided" log
+			expectedColumns: "user id,full name,email address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a copier with the test configuration
+			copier := &Copier{
+				skip:            1,
+				columnMapping:   ColumnsMapping(tt.columnMapping),
+				quoteCharacter:  tt.quoteCharacter,
+				escapeCharacter: tt.escapeCharacter,
+				logger:          &noopLogger{},
+			}
+
+			// Create a buffered reader with the test CSV headers
+			csvData := tt.csvHeaders + "\ndata1,data2,data3\n"
+			reader := strings.NewReader(csvData)
+			counter := &CountReader{Reader: reader}
+			bufferedReader := bufio.NewReaderSize(counter, 1024)
+
+			// Call the function under test
+			err := copier.calculateColumnsFromHeaders(bufferedReader)
+
+			// Check the results
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedColumns, copier.columns)
+			}
+		})
+	}
+}
+
+func TestCalculateColumnsFromHeaders_NoMapping(t *testing.T) {
+	// Test the case where no column mapping is provided
+	copier := &Copier{
+		skip:          1,
+		columnMapping: ColumnsMapping{}, // Empty mapping
+		logger:        &noopLogger{},
+	}
+
+	csvData := "id,name,email\ndata1,data2,data3\n"
+	reader := strings.NewReader(csvData)
+	counter := &CountReader{Reader: reader}
+	bufferedReader := bufio.NewReaderSize(counter, 1024)
+
+	err := copier.calculateColumnsFromHeaders(bufferedReader)
+
+	require.NoError(t, err)
+	assert.Equal(t, "id,name,email", copier.columns)
+}
+
+func TestColumnsMapping_Get(t *testing.T) {
+	mapping := ColumnsMapping{
+		{CSVColumnName: "user_id", DatabaseColumnName: "id"},
+		{CSVColumnName: "full_name", DatabaseColumnName: "name"},
+		{CSVColumnName: "email_address", DatabaseColumnName: "email"},
+	}
+
+	tests := []struct {
+		name           string
+		header         string
+		expectedColumn string
+		expectedFound  bool
+	}{
+		{
+			name:           "existing mapping",
+			header:         "user_id",
+			expectedColumn: "id",
+			expectedFound:  true,
+		},
+		{
+			name:           "another existing mapping",
+			header:         "email_address",
+			expectedColumn: "email",
+			expectedFound:  true,
+		},
+		{
+			name:           "non-existing mapping",
+			header:         "age",
+			expectedColumn: "",
+			expectedFound:  false,
+		},
+		{
+			name:           "empty header",
+			header:         "",
+			expectedColumn: "",
+			expectedFound:  false,
+		},
+		{
+			name:           "case sensitive",
+			header:         "USER_ID",
+			expectedColumn: "",
+			expectedFound:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			column, found := mapping.Get(tt.header)
+			assert.Equal(t, tt.expectedFound, found)
+			assert.Equal(t, tt.expectedColumn, column)
+		})
+	}
 }

--- a/pkg/csvcopy/options.go
+++ b/pkg/csvcopy/options.go
@@ -111,18 +111,10 @@ func WithColumns(columns string) Option {
 // WithSkipHeader is set, skips the first row of the csv file
 func WithSkipHeader(skipHeader bool) Option {
 	return func(c *Copier) error {
-		if c.skip != 0 {
-			return errors.New("skip is already set. Use only one of: WithSkipHeader or WithSkipHeaderCount")
-		}
-
 		if c.useFileHeaders != HeaderNone {
 			return errors.New("header handling is already configured. Use only one of: WithSkipHeader, WithColumnMapping, or WithAutoColumnMapping")
 		}
 		c.useFileHeaders = HeaderSkip
-
-		if skipHeader {
-			c.skip = 1
-		}
 		return nil
 	}
 }
@@ -131,7 +123,7 @@ func WithSkipHeader(skipHeader bool) Option {
 func WithSkipHeaderCount(headerLineCount int) Option {
 	return func(c *Copier) error {
 		if c.skip != 0 {
-			return errors.New("skip is already set. Use only one of: WithSkipHeader or WithSkipHeaderCount")
+			return errors.New("skip is already set")
 		}
 		if headerLineCount <= 0 {
 			return errors.New("header line count must be greater than zero")

--- a/pkg/csvcopy/options.go
+++ b/pkg/csvcopy/options.go
@@ -100,6 +100,9 @@ func WithEscapeCharacter(escapeCharacter string) Option {
 // WithColumns accepts a list of comma separated values for the csv columns
 func WithColumns(columns string) Option {
 	return func(c *Copier) error {
+		if len(c.columnMapping) > 0 {
+			return errors.New("column mapping is already set. Use only one of: WithColumns or WithColumnMapping")
+		}
 		c.columns = columns
 		return nil
 	}
@@ -109,7 +112,7 @@ func WithColumns(columns string) Option {
 func WithSkipHeader(skipHeader bool) Option {
 	return func(c *Copier) error {
 		if c.skip != 0 {
-			return errors.New("skip is already set. Use SkipHeader or SkipHeaderCount")
+			return errors.New("skip is already set. Use only one of: WithSkipHeader, WithSkipHeaderCount, or WithColumnMapping")
 		}
 		if skipHeader {
 			c.skip = 1
@@ -122,7 +125,7 @@ func WithSkipHeader(skipHeader bool) Option {
 func WithSkipHeaderCount(headerLineCount int) Option {
 	return func(c *Copier) error {
 		if c.skip != 0 {
-			return errors.New("skip is already set. Use SkipHeader or SkipHeaderCount")
+			return errors.New("skip is already set. Use only one of: WithSkipHeader, WithSkipHeaderCount, or WithColumnMapping")
 		}
 		if headerLineCount <= 0 {
 			return errors.New("header line count must be greater than zero")
@@ -290,6 +293,35 @@ func WithIdempotencyWindow(window time.Duration) Option {
 			return errors.New("idempotency window must be greater than zero")
 		}
 		c.idempotencyWindow = window
+		return nil
+	}
+}
+
+// WithColumnMapping sets the column mapping from CSV header names to database column names
+// Each ColumnMapping specifies CSVColumnName and DatabaseColumnName
+// This option automatically enables header skipping (sets skip to 1)
+func WithColumnMapping(mappings []ColumnMapping) Option {
+	return func(c *Copier) error {
+		if mappings == nil {
+			return errors.New("column mapping cannot be nil")
+		}
+		if c.skip != 0 {
+			return errors.New("skip is already set. Column mapping automatically handles header skipping")
+		}
+		if c.columns != "" {
+			return errors.New("columns are already set. Use only one of: WithColumns or WithColumnMapping")
+		}
+		for i, mapping := range mappings {
+			if mapping.CSVColumnName == "" {
+				return fmt.Errorf("column mapping at index %d has empty CSVColumnName", i)
+			}
+			if mapping.DatabaseColumnName == "" {
+				return fmt.Errorf("column mapping at index %d has empty DatabaseColumnName", i)
+			}
+		}
+		c.columnMapping = mappings
+		// Automatically set skip to 1 for header parsing
+		c.skip = 1
 		return nil
 	}
 }

--- a/pkg/csvcopy/options.go
+++ b/pkg/csvcopy/options.go
@@ -112,7 +112,7 @@ func WithColumns(columns string) Option {
 func WithSkipHeader(skipHeader bool) Option {
 	return func(c *Copier) error {
 		if c.skip != 0 {
-			return errors.New("skip is already set. Use only one of: WithSkipHeader, WithSkipHeaderCount, WithColumnMapping, or WithAutoColumnMapping")
+			return errors.New("skip is already set. Use only one of: WithSkipHeader or WithSkipHeaderCount")
 		}
 		if skipHeader {
 			c.skip = 1
@@ -125,7 +125,7 @@ func WithSkipHeader(skipHeader bool) Option {
 func WithSkipHeaderCount(headerLineCount int) Option {
 	return func(c *Copier) error {
 		if c.skip != 0 {
-			return errors.New("skip is already set. Use only one of: WithSkipHeader, WithSkipHeaderCount, WithColumnMapping, or WithAutoColumnMapping")
+			return errors.New("skip is already set. Use only one of: WithSkipHeader or WithSkipHeaderCount")
 		}
 		if headerLineCount <= 0 {
 			return errors.New("header line count must be greater than zero")
@@ -305,11 +305,11 @@ func WithColumnMapping(mappings []ColumnMapping) Option {
 		if mappings == nil {
 			return errors.New("column mapping cannot be nil")
 		}
-		if c.skip != 0 {
-			return errors.New("skip is already set. Column mapping automatically handles header skipping")
+		if c.useColumnMapping {
+			return errors.New("column mapping is already set. Use only one of: WithColumns, WithColumnMapping, or WithAutoColumnMapping")
 		}
 		if c.columns != "" {
-			return errors.New("columns are already set. Use only one of: WithColumns or WithColumnMapping")
+			return errors.New("columns are already set. Use only one of: WithColumns, WithColumnMapping, or WithAutoColumnMapping")
 		}
 		for i, mapping := range mappings {
 			if mapping.CSVColumnName == "" {
@@ -321,8 +321,6 @@ func WithColumnMapping(mappings []ColumnMapping) Option {
 		}
 		c.columnMapping = mappings
 		c.useColumnMapping = true
-		// Automatically set skip to 1 for header parsing
-		c.skip = 1
 		return nil
 	}
 }
@@ -332,19 +330,13 @@ func WithColumnMapping(mappings []ColumnMapping) Option {
 // This option automatically enables header skipping (sets skip to 1)
 func WithAutoColumnMapping() Option {
 	return func(c *Copier) error {
-		if c.skip != 0 {
-			return errors.New("skip is already set. Auto column mapping automatically handles header skipping")
-		}
 		if c.columns != "" {
-			return errors.New("columns are already set. Use only one of: WithColumns or WithAutoColumnMapping")
+			return errors.New("columns are already set. Use only one of: WithColumns, WithColumnMapping, or WithAutoColumnMapping")
 		}
-		if len(c.columnMapping) > 0 {
-			return errors.New("column mapping is already set. Use only one of: WithColumnMapping or WithAutoColumnMapping")
+		if c.useColumnMapping {
+			return errors.New("column mapping is already set. Use only one of: WithColumns, WithColumnMapping, or WithAutoColumnMapping")
 		}
 		c.useColumnMapping = true
-		// Leave columnMapping empty for auto mapping
-		// Automatically set skip to 1 for header parsing
-		c.skip = 1
 		return nil
 	}
 }

--- a/pkg/csvcopy/options.go
+++ b/pkg/csvcopy/options.go
@@ -100,7 +100,7 @@ func WithEscapeCharacter(escapeCharacter string) Option {
 // WithColumns accepts a list of comma separated values for the csv columns
 func WithColumns(columns string) Option {
 	return func(c *Copier) error {
-		if c.useColumnMapping {
+		if c.useFileHeaders == HeaderAutoColumnMapping || c.useFileHeaders == HeaderColumnMapping {
 			return errors.New("column mapping is already set. Use only one of: WithColumns, WithColumnMapping, or WithAutoColumnMapping")
 		}
 		c.columns = columns
@@ -114,6 +114,12 @@ func WithSkipHeader(skipHeader bool) Option {
 		if c.skip != 0 {
 			return errors.New("skip is already set. Use only one of: WithSkipHeader or WithSkipHeaderCount")
 		}
+
+		if c.useFileHeaders != HeaderNone {
+			return errors.New("header handling is already configured. Use only one of: WithSkipHeader, WithColumnMapping, or WithAutoColumnMapping")
+		}
+		c.useFileHeaders = HeaderSkip
+
 		if skipHeader {
 			c.skip = 1
 		}
@@ -305,8 +311,8 @@ func WithColumnMapping(mappings []ColumnMapping) Option {
 		if mappings == nil {
 			return errors.New("column mapping cannot be nil")
 		}
-		if c.useColumnMapping {
-			return errors.New("column mapping is already set. Use only one of: WithColumns, WithColumnMapping, or WithAutoColumnMapping")
+		if c.useFileHeaders != HeaderNone {
+			return errors.New("header handling is already configured. Use only one of: WithSkipHeader, WithColumnMapping, or WithAutoColumnMapping")
 		}
 		if c.columns != "" {
 			return errors.New("columns are already set. Use only one of: WithColumns, WithColumnMapping, or WithAutoColumnMapping")
@@ -320,7 +326,7 @@ func WithColumnMapping(mappings []ColumnMapping) Option {
 			}
 		}
 		c.columnMapping = mappings
-		c.useColumnMapping = true
+		c.useFileHeaders = HeaderColumnMapping
 		return nil
 	}
 }
@@ -330,13 +336,13 @@ func WithColumnMapping(mappings []ColumnMapping) Option {
 // This option automatically enables header skipping (sets skip to 1)
 func WithAutoColumnMapping() Option {
 	return func(c *Copier) error {
+		if c.useFileHeaders != HeaderNone {
+			return errors.New("header handling is already configured. Use only one of: WithSkipHeader, WithColumnMapping, or WithAutoColumnMapping")
+		}
 		if c.columns != "" {
 			return errors.New("columns are already set. Use only one of: WithColumns, WithColumnMapping, or WithAutoColumnMapping")
 		}
-		if c.useColumnMapping {
-			return errors.New("column mapping is already set. Use only one of: WithColumns, WithColumnMapping, or WithAutoColumnMapping")
-		}
-		c.useColumnMapping = true
+		c.useFileHeaders = HeaderAutoColumnMapping
 		return nil
 	}
 }

--- a/pkg/csvcopy/options_test.go
+++ b/pkg/csvcopy/options_test.go
@@ -1,0 +1,390 @@
+package csvcopy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOptionsMutualExclusivity(t *testing.T) {
+	tests := []struct {
+		name          string
+		options       []Option
+		expectError   bool
+		errorContains string
+	}{
+		// Valid individual configurations
+		{
+			name:        "WithSkipHeader alone should work",
+			options:     []Option{WithSkipHeader(true)},
+			expectError: false,
+		},
+		{
+			name:        "WithSkipHeader false should work",
+			options:     []Option{WithSkipHeader(false)},
+			expectError: false,
+		},
+		{
+			name: "WithColumnMapping alone should work",
+			options: []Option{WithColumnMapping([]ColumnMapping{
+				{CSVColumnName: "csv_col", DatabaseColumnName: "db_col"},
+			})},
+			expectError: false,
+		},
+		{
+			name:        "WithAutoColumnMapping alone should work",
+			options:     []Option{WithAutoColumnMapping()},
+			expectError: false,
+		},
+		{
+			name:        "WithColumns alone should work",
+			options:     []Option{WithColumns("col1,col2,col3")},
+			expectError: false,
+		},
+		{
+			name:        "WithSkipHeaderCount alone should work",
+			options:     []Option{WithSkipHeaderCount(2)},
+			expectError: false,
+		},
+
+		// Mutual exclusivity tests - WithSkipHeader conflicts
+		{
+			name: "WithSkipHeader + WithColumnMapping should fail",
+			options: []Option{
+				WithSkipHeader(true),
+				WithColumnMapping([]ColumnMapping{
+					{CSVColumnName: "csv_col", DatabaseColumnName: "db_col"},
+				}),
+			},
+			expectError:   true,
+			errorContains: "header handling is already configured",
+		},
+		{
+			name: "WithSkipHeader + WithAutoColumnMapping should fail",
+			options: []Option{
+				WithSkipHeader(true),
+				WithAutoColumnMapping(),
+			},
+			expectError:   true,
+			errorContains: "header handling is already configured",
+		},
+		{
+			name: "WithColumnMapping + WithSkipHeader should fail",
+			options: []Option{
+				WithColumnMapping([]ColumnMapping{
+					{CSVColumnName: "csv_col", DatabaseColumnName: "db_col"},
+				}),
+				WithSkipHeader(true),
+			},
+			expectError:   true,
+			errorContains: "header handling is already configured",
+		},
+		{
+			name: "WithAutoColumnMapping + WithSkipHeader should fail",
+			options: []Option{
+				WithAutoColumnMapping(),
+				WithSkipHeader(true),
+			},
+			expectError:   true,
+			errorContains: "header handling is already configured",
+		},
+
+		// Mutual exclusivity tests - Column mapping conflicts
+		{
+			name: "WithColumnMapping + WithAutoColumnMapping should fail",
+			options: []Option{
+				WithColumnMapping([]ColumnMapping{
+					{CSVColumnName: "csv_col", DatabaseColumnName: "db_col"},
+				}),
+				WithAutoColumnMapping(),
+			},
+			expectError:   true,
+			errorContains: "header handling is already configured",
+		},
+		{
+			name: "WithAutoColumnMapping + WithColumnMapping should fail",
+			options: []Option{
+				WithAutoColumnMapping(),
+				WithColumnMapping([]ColumnMapping{
+					{CSVColumnName: "csv_col", DatabaseColumnName: "db_col"},
+				}),
+			},
+			expectError:   true,
+			errorContains: "header handling is already configured",
+		},
+
+		// Triple conflicts
+		{
+			name: "All three options should fail",
+			options: []Option{
+				WithSkipHeader(true),
+				WithColumnMapping([]ColumnMapping{
+					{CSVColumnName: "csv_col", DatabaseColumnName: "db_col"},
+				}),
+				WithAutoColumnMapping(),
+			},
+			expectError:   true,
+			errorContains: "header handling is already configured",
+		},
+
+		// WithColumns conflicts with column mapping
+		{
+			name: "WithColumns + WithColumnMapping should fail",
+			options: []Option{
+				WithColumns("col1,col2"),
+				WithColumnMapping([]ColumnMapping{
+					{CSVColumnName: "csv_col", DatabaseColumnName: "db_col"},
+				}),
+			},
+			expectError:   true,
+			errorContains: "columns are already set",
+		},
+		{
+			name: "WithColumns + WithAutoColumnMapping should fail",
+			options: []Option{
+				WithColumns("col1,col2"),
+				WithAutoColumnMapping(),
+			},
+			expectError:   true,
+			errorContains: "columns are already set",
+		},
+		{
+			name: "WithColumnMapping + WithColumns should fail",
+			options: []Option{
+				WithColumnMapping([]ColumnMapping{
+					{CSVColumnName: "csv_col", DatabaseColumnName: "db_col"},
+				}),
+				WithColumns("col1,col2"),
+			},
+			expectError:   true,
+			errorContains: "column mapping is already set",
+		},
+		{
+			name: "WithAutoColumnMapping + WithColumns should fail",
+			options: []Option{
+				WithAutoColumnMapping(),
+				WithColumns("col1,col2"),
+			},
+			expectError:   true,
+			errorContains: "column mapping is already set",
+		},
+
+		// WithSkipHeader vs WithSkipHeaderCount conflicts
+		{
+			name: "WithSkipHeader + WithSkipHeaderCount should fail",
+			options: []Option{
+				WithSkipHeader(true),
+				WithSkipHeaderCount(2),
+			},
+			expectError:   true,
+			errorContains: "skip is already set",
+		},
+		{
+			name: "WithSkipHeaderCount + WithSkipHeader should fail",
+			options: []Option{
+				WithSkipHeaderCount(2),
+				WithSkipHeader(true),
+			},
+			expectError:   true,
+			errorContains: "skip is already set",
+		},
+
+		// Valid combinations that should work
+		{
+			name: "WithSkipHeader false + WithColumns should work",
+			options: []Option{
+				WithSkipHeader(false),
+				WithColumns("col1,col2"),
+			},
+			expectError: false,
+		},
+		{
+			name: "WithSkipHeaderCount + WithColumns should work",
+			options: []Option{
+				WithSkipHeaderCount(2),
+				WithColumns("col1,col2"),
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewCopier("test-conn", "test-table", tt.options...)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("Expected error to contain '%s', but got: %s", tt.errorContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %s", err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestColumnMappingValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		mappings      []ColumnMapping
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "Valid column mapping should work",
+			mappings: []ColumnMapping{
+				{CSVColumnName: "csv_col1", DatabaseColumnName: "db_col1"},
+				{CSVColumnName: "csv_col2", DatabaseColumnName: "db_col2"},
+			},
+			expectError: false,
+		},
+		{
+			name:          "Nil mappings should fail",
+			mappings:      nil,
+			expectError:   true,
+			errorContains: "column mapping cannot be nil",
+		},
+		{
+			name: "Empty CSV column name should fail",
+			mappings: []ColumnMapping{
+				{CSVColumnName: "", DatabaseColumnName: "db_col"},
+			},
+			expectError:   true,
+			errorContains: "empty CSVColumnName",
+		},
+		{
+			name: "Empty database column name should fail",
+			mappings: []ColumnMapping{
+				{CSVColumnName: "csv_col", DatabaseColumnName: ""},
+			},
+			expectError:   true,
+			errorContains: "empty DatabaseColumnName",
+		},
+		{
+			name: "Multiple mappings with one invalid should fail",
+			mappings: []ColumnMapping{
+				{CSVColumnName: "csv_col1", DatabaseColumnName: "db_col1"},
+				{CSVColumnName: "", DatabaseColumnName: "db_col2"},
+			},
+			expectError:   true,
+			errorContains: "empty CSVColumnName",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewCopier("test-conn", "test-table", WithColumnMapping(tt.mappings))
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("Expected error to contain '%s', but got: %s", tt.errorContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %s", err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestHeaderHandlingEnumValues(t *testing.T) {
+	tests := []struct {
+		name           string
+		option         Option
+		expectedHeader HeaderHandling
+	}{
+		{
+			name:           "WithSkipHeader(true) should set HeaderSkip",
+			option:         WithSkipHeader(true),
+			expectedHeader: HeaderSkip,
+		},
+		{
+			name:           "WithSkipHeader(false) should keep HeaderNone",
+			option:         WithSkipHeader(false),
+			expectedHeader: HeaderNone,
+		},
+		{
+			name:           "WithAutoColumnMapping should set HeaderAutoColumnMapping",
+			option:         WithAutoColumnMapping(),
+			expectedHeader: HeaderAutoColumnMapping,
+		},
+		{
+			name: "WithColumnMapping should set HeaderColumnMapping",
+			option: WithColumnMapping([]ColumnMapping{
+				{CSVColumnName: "csv_col", DatabaseColumnName: "db_col"},
+			}),
+			expectedHeader: HeaderColumnMapping,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			copier, err := NewCopier("test-conn", "test-table", tt.option)
+			if err != nil {
+				t.Errorf("Unexpected error: %s", err.Error())
+				return
+			}
+
+			if copier.useFileHeaders != tt.expectedHeader {
+				t.Errorf("Expected useFileHeaders to be %d, but got %d", tt.expectedHeader, copier.useFileHeaders)
+			}
+		})
+	}
+}
+
+func TestSkipHeaderCountValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		count         int
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:        "Valid skip count should work",
+			count:       3,
+			expectError: false,
+		},
+		{
+			name:          "Zero skip count should fail",
+			count:         0,
+			expectError:   true,
+			errorContains: "header line count must be greater than zero",
+		},
+		{
+			name:          "Negative skip count should fail",
+			count:         -1,
+			expectError:   true,
+			errorContains: "header line count must be greater than zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewCopier("test-conn", "test-table", WithSkipHeaderCount(tt.count))
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("Expected error to contain '%s', but got: %s", tt.errorContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %s", err.Error())
+				}
+			}
+		})
+	}
+}

--- a/pkg/csvcopy/options_test.go
+++ b/pkg/csvcopy/options_test.go
@@ -311,7 +311,7 @@ func TestHeaderHandlingEnumValues(t *testing.T) {
 		{
 			name:           "WithSkipHeader(false) should keep HeaderNone",
 			option:         WithSkipHeader(false),
-			expectedHeader: HeaderNone,
+			expectedHeader: HeaderSkip,
 		},
 		{
 			name:           "WithAutoColumnMapping should set HeaderAutoColumnMapping",

--- a/pkg/csvcopy/options_test.go
+++ b/pkg/csvcopy/options_test.go
@@ -168,25 +168,6 @@ func TestOptionsMutualExclusivity(t *testing.T) {
 			errorContains: "column mapping is already set",
 		},
 
-		// WithSkipHeader vs WithSkipHeaderCount conflicts
-		{
-			name: "WithSkipHeader + WithSkipHeaderCount should fail",
-			options: []Option{
-				WithSkipHeader(true),
-				WithSkipHeaderCount(2),
-			},
-			expectError:   true,
-			errorContains: "skip is already set",
-		},
-		{
-			name: "WithSkipHeaderCount + WithSkipHeader should fail",
-			options: []Option{
-				WithSkipHeaderCount(2),
-				WithSkipHeader(true),
-			},
-			expectError:   true,
-			errorContains: "skip is already set",
-		},
 
 		// Valid combinations that should work
 		{
@@ -202,6 +183,14 @@ func TestOptionsMutualExclusivity(t *testing.T) {
 			options: []Option{
 				WithSkipHeaderCount(2),
 				WithColumns("col1,col2"),
+			},
+			expectError: false,
+		},
+		{
+			name: "WithSkipHeader + WithSkipHeaderCount should work",
+			options: []Option{
+				WithSkipHeader(true),
+				WithSkipHeaderCount(3),
 			},
 			expectError: false,
 		},

--- a/pkg/csvcopy/scan.go
+++ b/pkg/csvcopy/scan.go
@@ -351,8 +351,8 @@ func (c *CountReader) Read(b []byte) (int, error) {
 	return n, err
 }
 
-// skipHeaders skips the specified number of header lines without parsing them
-func skipHeaders(reader *bufio.Reader, skip int) error {
+// skipLines skips the specified number of lines starting from the very beginning of the file.
+func skipLines(reader *bufio.Reader, skip int) error {
 	for skip > 0 {
 		// The use of ReadLine() here avoids copying or buffering data that
 		// we're just going to discard.
@@ -362,7 +362,7 @@ func skipHeaders(reader *bufio.Reader, skip int) error {
 			// No data?
 			return nil
 		} else if err != nil {
-			return fmt.Errorf("skipping header: %w", err)
+			return fmt.Errorf("skipping line: %w", err)
 		}
 		if !isPrefix {
 			// We pulled a full row from the buffer.

--- a/pkg/csvcopy/scan.go
+++ b/pkg/csvcopy/scan.go
@@ -373,11 +373,7 @@ func skipHeaders(reader *bufio.Reader, skip int) error {
 }
 
 // parseHeaders parses the first header line and skips remaining header lines
-func parseHeaders(reader *bufio.Reader, skip int, quote, escape byte, comma rune) ([]string, error) {
-	if skip == 0 {
-		return []string{}, nil
-	}
-
+func parseHeaders(reader *bufio.Reader, quote, escape byte, comma rune) ([]string, error) {
 	// Read the first header line
 	var headerLine []byte
 	for {

--- a/pkg/csvcopy/scan.go
+++ b/pkg/csvcopy/scan.go
@@ -148,7 +148,7 @@ func scan(ctx context.Context, counter *CountReader, reader *bufio.Reader, out c
 		select {
 		case out <- newBatch(
 			bufs,
-			newLocation(opts.ImportID, rowsRead, bufferedRows, opts.Skip, byteStart, byteEnd-byteStart), // Skip is 0 since we already skipped
+			newLocation(opts.ImportID, rowsRead, bufferedRows, opts.Skip, byteStart, byteEnd-byteStart),
 		):
 		case <-ctx.Done():
 			return ctx.Err()
@@ -237,7 +237,7 @@ func scan(ctx context.Context, counter *CountReader, reader *bufio.Reader, out c
 		select {
 		case out <- newBatch(
 			bufs,
-			newLocation(opts.ImportID, rowsRead, bufferedRows, opts.Skip, byteStart, byteEnd-byteStart), // Skip is 0 since we already skipped
+			newLocation(opts.ImportID, rowsRead, bufferedRows, opts.Skip, byteStart, byteEnd-byteStart),
 		):
 		case <-ctx.Done():
 			return ctx.Err()

--- a/pkg/csvcopy/scan_test.go
+++ b/pkg/csvcopy/scan_test.go
@@ -346,6 +346,25 @@ d"
 				2,
 			},
 		},
+		{
+			name: "skip first lines, then parse headers",
+			input: []string{
+				`# This is a comment`,
+				`# This is another comment`,
+				`# And the following line contain the actual headers`,
+				`a,b,c`,
+				`1,2,3`,
+				`4,5,6`,
+			},
+			size: 3,
+			skip: 3, // skip the comments, not the header line
+			expected: []string{
+				"a,b,c\n1,2,3\n4,5,6",
+			},
+			expectedRowCount: []int{
+				3,
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -386,7 +405,7 @@ d"
 
 			// Skip headers if needed
 			if opts.Skip > 0 {
-				err := skipHeaders(bufferedReader, opts.Skip)
+				err := skipLines(bufferedReader, opts.Skip)
 				if err != nil {
 					assert.NoError(t, err)
 					return
@@ -448,7 +467,7 @@ d"
 
 			// Skip headers if needed
 			if opts.Skip > 0 {
-				err := skipHeaders(bufferedReader, opts.Skip)
+				err := skipLines(bufferedReader, opts.Skip)
 				if !errors.Is(err, expected) {
 					t.Errorf("Scan() returned unexpected error: %v", err)
 					t.Logf("want: %v", expected)
@@ -569,7 +588,7 @@ func BenchmarkScan(b *testing.B) {
 
 					// Skip headers if needed
 					if opts.Skip > 0 {
-						err := skipHeaders(bufferedReader, opts.Skip)
+						err := skipLines(bufferedReader, opts.Skip)
 						if err != nil {
 							b.Errorf("Failed to skip headers: %v", err)
 							return


### PR DESCRIPTION
The current implementation only supports `--column-names` which requires the user to manually provide the names for the database columns. 

Given that CSV files already support headers, adding `--auto-column-mapping` allows to take advantage of such information and use it to build `--column-names` dynamically. This is less error prone and more flexible. 

The `--column-mapping` flag is added along with `--auto-column-mapping` because it resolves another common problem where your input csv column names do not match the database column names. `--auto-column-mapping` is a concrete case of `--column-mapping` where source and destination are the same name.