### PR TITLE
chore: Bump go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/timescale/timescaledb-parallel-copy
 
-go 1.22.0
+go 1.23.11
 
-toolchain go1.23.4
+toolchain go1.23.11
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Go 1.22 is end-of-life since Feb 2025. Use a currently supported version.