### PR TITLE
feat: add WithQueueSize option to csvcopy.NewCopier

### DIFF
--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -55,6 +55,7 @@ type Copier struct {
 	escapeCharacter   string
 	columns           string
 	workers           int
+	queueSize        int
 	limit             int64
 	bufferSize        int
 	batchByteSize     int
@@ -97,6 +98,7 @@ func NewCopier(
 		escapeCharacter:   "",
 		columns:           "",
 		workers:           1,
+		queueSize:         0,
 		limit:             0,
 		bufferSize:        10 * 1024 * 1024,
 		batchByteSize:     50 * 1024 * 1024,
@@ -181,8 +183,13 @@ func (c *Copier) Copy(ctx context.Context, reader io.Reader) (Result, error) {
 		}
 	}
 
+	queueSize := c.workers * 2
+	if c.queueSize > 0 {
+		queueSize = c.queueSize
+	}
+
 	var workerWg sync.WaitGroup
-	batchChan := make(chan Batch, c.workers*2)
+	batchChan := make(chan Batch, queueSize)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/csvcopy/options.go
+++ b/pkg/csvcopy/options.go
@@ -144,6 +144,18 @@ func WithWorkers(workers int) Option {
 	}
 }
 
+// WithQueueSize sets the size of the channel used to transfer batches from the producer to workers.
+// The default queue size is 2 * workers.
+func WithQueueSize(queueSize int) Option {
+	return func(c *Copier) error {
+		if queueSize <= 0 {
+			return errors.New("queueSize must be greater than zero")
+		}
+		c.queueSize = queueSize
+		return nil
+	}
+}
+
 // WithLimit limits the number of imported rows
 func WithLimit(limit int64) Option {
 	return func(c *Copier) error {

--- a/pkg/csvcopy/options_test.go
+++ b/pkg/csvcopy/options_test.go
@@ -3,6 +3,8 @@ package csvcopy
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestOptionsMutualExclusivity(t *testing.T) {
@@ -377,3 +379,14 @@ func TestSkipHeaderCountValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestQueueSizeSetsQueueSize(t *testing.T) {
+	copier, err := NewCopier("connstr", "table", WithQueueSize(2))
+	require.NoError(t, err)
+	require.Equal(t, 2, copier.queueSize)
+
+	copier, err = NewCopier("connstr", "table")
+	require.NoError(t, err)
+	require.Equal(t, 0, copier.queueSize)
+}
+


### PR DESCRIPTION
The csvcopy.Copy function sets up one producer and a configurable number of workers (using WithWorkers). The default number of workers is 8. The producer transfers batches of CSV rows to be written using a queue. The default size of the queue is 2*workers.

The WithQueueSize option makes it possible to override the default queue size.