### PR TITLE
fix: add buffer size to 'buffer too small' error

### DIFF
--- a/pkg/csvcopy/scan.go
+++ b/pkg/csvcopy/scan.go
@@ -173,7 +173,7 @@ func scan(ctx context.Context, pool *buffer.Pool, logger func(ctx context.Contex
 		switch err {
 		case bufio.ErrBufferFull:
 			// If we hit buffer full, we do not have enough data to read a full row
-			return fmt.Errorf("reading lines, %w. you should probably increase batch size", err)
+			return fmt.Errorf("buffer of size %d too small for row, you should probably increase batch size: %w", reader.Size(), err)
 
 		case io.EOF:
 			// Also fine, but unlike ErrBufferFull we won't have another

--- a/pkg/csvcopy/scan_test.go
+++ b/pkg/csvcopy/scan_test.go
@@ -304,7 +304,7 @@ d"
 			size:          2,
 			batchSize:     1024,
 			bufferSize:    2048,
-			expectedError: "you should probably increase batch size",
+			expectedError: "buffer of size 2048 too small for row, you should probably increase batch size",
 		},
 		{
 			name: "batch size is hit before line limit",


### PR DESCRIPTION
The current error tells us that the batch size should probably be
increased, but it doesn't tell us what the current size is, which would
be useful to know.