### PR TITLE
fix: correct disable-direct-compress logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Usage of timescaledb-parallel-copy:
   -db-name string
         (deprecated) Database where the destination table exists
   -disable-direct-compress
-        Do not use direct compress to write data to TimescaleDB. Default: on
+        Disable using direct compress to write data to TimescaleDB.
   -enable-client-side-sorting
         Guaranteed data order in place on the client side, can improve ingest performance. Default: off
   -escape character

--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -60,7 +60,7 @@ var (
 
 	dbName string
 
-	directCompress    bool
+	disableDirectCompress bool
 	clientSideSorting bool
 
 	windows1252HandlingDisabled bool
@@ -107,7 +107,7 @@ func init() {
 
 	flag.BoolVar(&showVersion, "version", false, "Show the version of this tool")
 
-	flag.BoolVar(&directCompress, "disable-direct-compress", false, "Do not use direct compress to write data to TimescaleDB")
+	flag.BoolVar(&disableDirectCompress, "disable-direct-compress", false, "Disable using direct compress to write data to TimescaleDB")
 	flag.BoolVar(&clientSideSorting, "enable-client-side-sorting", false, "Guaranteed data order in place on the client side")
 
 	flag.BoolVar(&windows1252HandlingDisabled, "disable-windows-1252-handling", false, "Disable automatic encoding handling")
@@ -199,9 +199,8 @@ func main() {
 		opts = append(opts, csvcopy.WithSkipHeader(true))
 	}
 
-	if directCompress {
-		opts = append(opts, csvcopy.WithDirectCompress(true))
-	}
+	opts = append(opts, csvcopy.WithDirectCompress(!disableDirectCompress))
+
 	if clientSideSorting {
 		opts = append(opts, csvcopy.WithClientSideSorting(true))
 	}

--- a/pkg/csvcopy/csvcopy.go
+++ b/pkg/csvcopy/csvcopy.go
@@ -529,12 +529,12 @@ func (c *Copier) processBatches(ctx context.Context, ch chan Batch, workerID int
 
 	if c.verbose {
 		c.LogInfo(ctx, "connected to service")
-		c.LogInfo(ctx, fmt.Sprintf("setting direct compress to '%t' for the session", !c.directCompress))
+		c.LogInfo(ctx, fmt.Sprintf("setting direct compress to '%t' for the session", c.directCompress))
 		c.LogInfo(ctx, fmt.Sprintf("setting client side sorting to '%t' for the session", c.clientSideSorting))
 	}
 
 	// set Direct Compress GUCs for session
-	if _, err := dbx.Exec(fmt.Sprintf("SET timescaledb.enable_direct_compress_copy=%t", !c.directCompress)); err != nil {
+	if _, err := dbx.Exec(fmt.Sprintf("SET timescaledb.enable_direct_compress_copy=%t", c.directCompress)); err != nil {
 		return err
 	}
 	// set Direct Compress's client side sorting GUCs for session


### PR DESCRIPTION
When using timescaledb-parallel-copy as a library, the logic to enable direct compress was inverted.