### PR TITLE
feat!: rename to -dangerously-enable-client-side-sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ Usage of timescaledb-parallel-copy:
         (deprecated) Database where the destination table exists
   -disable-direct-compress
         Disable using direct compress to write data to TimescaleDB.
-  -enable-client-side-sorting
-        Guaranteed data order in place on the client side, can improve ingest performance. Default: off
+  -dangerously-enable-client-side-sorting
+        Dangerous: Guarantees that data is pre-sorted, and that every batch is non-overlapping, see TimescaleDB GUC enable_direct_compress_copy_client_sorted
   -escape character
         The ESCAPE character to use during COPY (default '"')
   -file string

--- a/cmd/timescaledb-parallel-copy/main.go
+++ b/cmd/timescaledb-parallel-copy/main.go
@@ -108,7 +108,7 @@ func init() {
 	flag.BoolVar(&showVersion, "version", false, "Show the version of this tool")
 
 	flag.BoolVar(&disableDirectCompress, "disable-direct-compress", false, "Disable using direct compress to write data to TimescaleDB")
-	flag.BoolVar(&clientSideSorting, "enable-client-side-sorting", false, "Guaranteed data order in place on the client side")
+	flag.BoolVar(&clientSideSorting, "dangerously-enable-client-side-sorting", false, "Dangerous: Guarantees that data is pre-sorted, and that every batch is non-overlapping, see TimescaleDB GUC enable_direct_compress_copy_client_sorted")
 
 	flag.BoolVar(&windows1252HandlingDisabled, "disable-windows-1252-handling", false, "Disable automatic encoding handling")
 


### PR DESCRIPTION
The name 'enable-client-side-sorting' gives one the sense that it could be innocuous to enable.

It maps directly to the enable_direct_compress_copy_client_sorted TimescaleDB GUC, which allows clients to guarantee that all data is in sorted order and that there are no overlapping ranges of data in different compressed batches.

Due to the nature of timescaledb-parallel-copy, this is only safe to use when the following restrictions apply to the data to be inserted:
- It does not overlap (in the time dimension) with any data which is already stored in compressed form in the database.
- It is in sorted order (corresponding to the compression settings on the target table, i.e. taking time dimension, segmenting and ordering configuration into account).
- It is strictly monotonic in the time dimension (taking segment by settings into account).

Failure to adhere to these restrictions can result in incorrect query results.