### PR TITLE
chore: add CODEOWNERS for connectors team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @timescale/connectors


### PR DESCRIPTION
Declares `@timescale/connectors` as the root code owner. Enables team-connectors tooling to discover owned repos dynamically.